### PR TITLE
[#93] Fixed Github actions crashes on the build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
             <version>${mapstruct-version}</version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,8 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+#TODO replace spring.datasource.url value with remote production database url
 spring.datasource.url=jdbc:mysql://localhost:3306/switchboard?useSSL=false&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=root
+#TODO Add database credentials
+spring.datasource.username=
+spring.datasource.password=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,8 +2,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-#TODO replace spring.datasource.url value with remote production database url
+#TODO if applicable, edit datasource properties
 spring.datasource.url=jdbc:mysql://localhost:3306/switchboard?useSSL=false&serverTimezone=UTC
-#TODO Add database credentials
-spring.datasource.username=
-spring.datasource.password=
+spring.datasource.username=root
+spring.datasource.password=root

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-#TODO if applicable, edit datasource properties
+#TODO if applicable, edit datasource properties (CAUTION: do not push changes to version control)
 spring.datasource.url=jdbc:mysql://localhost:3306/switchboard?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
 spring.datasource.password=root

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,0 @@
-/* This data is only loaded when using h2 in memory database,to enable h2: uncomment the line "#spring.datasource.url=jdbc:h2:mem:testdb"
-   in application.properties
- */
-
-insert into device(serial_number, display_name, Status) values (1,'Device1','Running');
-insert into device(serial_number, display_name, Status) values (2,'Device2','Running');
-insert into encoderEntity(serial_number) values(1);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,7 +1,6 @@
+spring.h2.console.enabled=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-spring.datasource.url=jdbc:mysql://localhost:3306/switchboard?useSSL=false&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.url=jdbc:h2:mem:test


### PR DESCRIPTION
# General info

Fixed Github actions crashes on the build step with separate embedded database configuration for testing

**Issue number**: #93 

**Task description**: 

 - Updated src/main/resources/application.properties
 - Created src/test/resources/application.properties
 - Delete src/main/resources/data.sql (clean up)
 - Added H2 Database dependency
 - Updated .github/workflows/build.yml

# Testing

**Test coverage**:
n/a

# Additional notes

**Note to reviewers**:
I changed the production database name to 'switchboard' instead of 'testdb'. Once we get a production database running remotely, it would be wise not to include such properties in a public repo.

**To do before merging**:
n/a
