### PR TITLE
[#117] Allow DB connections when user hasn't logged in to the database before

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@ spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 #TODO if applicable, edit datasource properties (CAUTION: do not push changes to version control)
-spring.datasource.url=jdbc:mysql://localhost:3306/switchboard?useSSL=false&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://localhost:3306/testdb?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=root
 spring.datasource.password=root
+


### PR DESCRIPTION
# General info
This enables the back-end to connect to the database even though the DB hasn't been logged in to before.
see https://dev.mysql.com/doc/dev/connector-net/8.0/html/P_MySql_Data_MySqlClient_MySqlConnectionStringBuilder_AllowPublicKeyRetrieval.htm

**Issue number**: #117

**Task description**: 

 - enable allowPublicKeyRetrieval for database connections

# Testing

**Test coverage**:
N/A

# Additional notes