### PR TITLE
Improved linter rules for frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17614,7 +17614,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -17632,7 +17631,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -17663,7 +17661,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -17675,7 +17672,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -17744,7 +17740,6 @@
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -17800,7 +17795,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17726,7 +17726,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -17735,7 +17734,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,8 @@
   "eslintConfig": {
     "env": {
       "browser": true,
-      "es6": true
+      "es6": true,
+      "jest": true
     },
     "extends": [
       "plugin:react/recommended",
@@ -58,6 +59,8 @@
       "react"
     ],
     "rules": {
+      "prettier/prettier": "warn",
+      "spaced-comment": "warn",
       "class-methods-use-this": "warn",
       "import/named": "warn",
       "no-plusplus": "warn",
@@ -76,7 +79,31 @@
       "react/no-array-index-key": "warn",
       "react/prefer-stateless-function": "warn",
       "react/prop-types": "warn",
-      "react/sort-comp": "warn"
+      "react/sort-comp": "warn",
+      "react/display-name": "warn",
+      "react/jsx-key": "warn",
+      "react/jsx-no-comment-textnodes": "warn",
+      "react/jsx-no-duplicate-props": "warn",
+      "react/jsx-no-target-blank": "warn",
+      "react/jsx-no-undef": "warn",
+      "react/jsx-uses-react": "warn",
+      "react/jsx-uses-vars": "warn",
+      "react/no-children-prop": "warn",
+      "react/no-danger-with-children": "warn",
+      "react/no-deprecated": "warn",
+      "react/no-direct-mutation-state": "warn",
+      "react/no-find-dom-node": "warn",
+      "react/no-is-mounted": "warn",
+      "react/no-render-return-value": "error",
+      "react/no-string-refs": "error",
+      "react/no-unescaped-entities": "warn",
+      "react/no-unknown-property": "warn",
+      "react/react-in-jsx-scope": "warn",
+      "react/require-render-return": "error",
+      "react/jsx-equals-spacing": "warn",
+      "react/jsx-tag-spacing": "warn",
+      "react/jsx-indent": "warn",
+      "react/jsx-indent-props": "warn"
     }
   },
   "browserslist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,8 @@
     "lint:fix": "prettier --write \"src/**/*.+(html|css|json|md)\" && eslint --fix src/ --ext .js,.jsx"
   },
   "prettier": {
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "endOfLine": "auto"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: Related to #150 
**Task description**: 

 - Ignored line ending characters in Prettier
- Configured a bunch of prettier and eslint rules to be warnings instead of errors - like this, we won't get the build blocked for minor stuff like spacing, but we will still see warnings as code smells in pull requests. Should lower the impact on dev flow while keeping the linting relatively easy.
 - Added Jest to eslint globals to remove false positives related to jest globals being undefined in the eyes of the linter.


# Testing

No code changes
