### PR TITLE
[#164] Adjusted mapper classes to properly populate fields of channels

### DIFF
--- a/src/main/java/org/beanpod/switchboard/dto/mapper/DecoderMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/DecoderMapper.java
@@ -4,12 +4,18 @@ import java.util.List;
 import org.beanpod.switchboard.dto.DecoderDTO;
 import org.beanpod.switchboard.entity.DecoderEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(
     componentModel = "spring",
     uses = {DeviceMapper.class, InputChannelMapper.class})
 public interface DecoderMapper {
   DecoderDTO toDecoderDTO(DecoderEntity decoderEntity);
+
+  @Named("toDecoderDTOShallow")
+  @Mapping(target = "input", ignore = true)
+  DecoderDTO toDecoderDTOShallow(DecoderEntity decoderEntity);
 
   List<DecoderDTO> toDecoderDTOs(List<DecoderEntity> decoderEntities);
 

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/EncoderMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/EncoderMapper.java
@@ -4,12 +4,18 @@ import java.util.List;
 import org.beanpod.switchboard.dto.EncoderDTO;
 import org.beanpod.switchboard.entity.EncoderEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(
     componentModel = "spring",
     uses = {DeviceMapper.class, OutputChannelMapper.class})
 public interface EncoderMapper {
   EncoderDTO toEncoderDTO(EncoderEntity encoderEntity);
+
+  @Named("toEncoderDTOShallow")
+  @Mapping(target = "output", ignore = true)
+  EncoderDTO toEncoderDTOShallow(EncoderEntity encoderEntity);
 
   List<EncoderDTO> toEncoderDTOs(List<EncoderEntity> encoderEntities);
 

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/InputChannelMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/InputChannelMapper.java
@@ -5,16 +5,21 @@ import org.beanpod.switchboard.dto.InputChannelDTO;
 import org.beanpod.switchboard.entity.InputChannelEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.openapitools.model.InputChannelModel;
 
 @Mapper(
     componentModel = "spring",
     uses = {DecoderMapper.class, ChannelMapper.class})
 public interface InputChannelMapper {
-  @Mapping(target = "decoder", ignore = true)
+  @Mapping(target = "decoder", qualifiedByName = "toDecoderDTOShallow")
   InputChannelDTO toInputChannelDTO(InputChannelEntity inputChannelEntity);
 
   @Mapping(target = "decoder", ignore = true)
   Set<InputChannelDTO> toInputChannelDTOs(Set<InputChannelEntity> inputChannelEntities);
 
   InputChannelEntity toInputChannelEntity(InputChannelDTO inputChannelDTO);
+
+  @Mapping(target = "name", source = "channel.name")
+  @Mapping(target = "port", source = "channel.port")
+  InputChannelModel inputChannelDTOToInputChannelModel(InputChannelDTO inputChannelDTO);
 }

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/OutputChannelMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/OutputChannelMapper.java
@@ -5,16 +5,21 @@ import org.beanpod.switchboard.dto.OutputChannelDTO;
 import org.beanpod.switchboard.entity.OutputChannelEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.openapitools.model.OutputChannelModel;
 
 @Mapper(
     componentModel = "spring",
     uses = {EncoderMapper.class, ChannelMapper.class})
 public interface OutputChannelMapper {
-  @Mapping(target = "encoder", ignore = true)
+  @Mapping(target = "encoder", qualifiedByName = "toEncoderDTOShallow")
   OutputChannelDTO toOutputChannelDTO(OutputChannelEntity outputChannelEntity);
 
   @Mapping(target = "encoder", ignore = true)
   Set<OutputChannelDTO> toOutputChannelDTOs(Set<OutputChannelEntity> outputChannelEntities);
 
   OutputChannelEntity toOutputChannelEntity(OutputChannelDTO outputChannelDTO);
+
+  @Mapping(target = "name", source = "channel.name")
+  @Mapping(target = "port", source = "channel.port")
+  OutputChannelModel outputChannelDTOToOutputChannelModel(OutputChannelDTO outputChannelDTO);
 }


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: #164 

**Task description**: 

 Fixed the bug in the linked issue

In Mapstruct mapping classes, the `decoder` property for an input channel was being ignored. This prevents a stack overflow because the decoder mapping method will create an input channel which loops forever. I fixed this issue by defining two new mapper methods
- A "shallow" decoder mapping method that does not map its channels
- A "shallow" input channel mapping method that calls the shallow decoder mapping method
This allow us to only map down to the decoder level when getting all streams, but to still only map down to the channel level when getting the decoders. I also made the same fix for the output channels / encoders.

Also, when mapping to the input channel / output channel models, the mapper was not mapping the name and channel, because those properties were inside the channel property of the input channel / output channel. Simply adding mapping annotations for them was sufficient to fix the issue.
 
### Bugged response for get all streams

```
{
    "id": 5,
    "inputChannel": {
        "id": 4,
        "name": null,
        "port": null,
        "decoder": null
    },
    "outputChannel": {
        "id": 3,
        "name": null,
        "port": null,
        "encoder": null
    }
}
```

### Fixed response for get all streams

```
{
    "id": 5,
    "inputChannel": {
        "id": 4,
        "name": "Channel One",
        "port": 2000,
        "decoder": {
            "serialNumber": "z7VBn9aK",
            "device": {
                "serialNumber": "z7VBn9aK",
                "ipAddress": "127.0.0.1",
                "displayName": "sample_receiver",
                "status": "Running"
            }
        }
    },
    "outputChannel": {
        "id": 3,
        "name": "Channel Two",
        "port": 2000,
        "encoder": {
            "serialNumber": "d7TxFn7o",
            "device": {
                "serialNumber": "d7TxFn7o",
                "ipAddress": "127.0.0.1",
                "displayName": "sample_sender",
                "status": "Running"
            }
        }
    }
}
```

# Testing

**Test coverage**: