### PR TITLE
Refactor Channel details table

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,3 +24,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+debug.log

--- a/frontend/debug.log
+++ b/frontend/debug.log
@@ -1,0 +1,3 @@
+[1123/221214.290:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1126/171039.206:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1130/144232.386:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/frontend/debug.log
+++ b/frontend/debug.log
@@ -1,3 +1,0 @@
-[1123/221214.290:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
-[1126/171039.206:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
-[1130/144232.386:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/frontend/src/devicelist/ChannelDetailsTable.jsx
+++ b/frontend/src/devicelist/ChannelDetailsTable.jsx
@@ -1,46 +1,31 @@
 import React from "react";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow
-} from "@material-ui/core";
+import { Table, TableBody, TableHead } from "@material-ui/core";
 import PropTypes from "prop-types";
 import InputChannelInfo from "../model/InputChannelInfo";
 import OutputChannelInfo from "../model/OutputChannelInfo";
+import ChannelDetailsTableHead from "./ChannelDetailsTableHead";
+import ChannelDetailsTableRow from "./ChannelDetailsTableRow";
 
-export default class ChannelDetailsTable extends React.Component {
-  render() {
-    const {
-      channel: { id, name, port }
-    } = this.props;
-    return (
-      <Table
-        style={{ margin: "1em", maxWidth: "98%" }}
-        className="flexContents"
-      >
-        <TableHead>
-          <TableRow>
-            <TableCell className="lightGrey">ID</TableCell>
-            <TableCell className="lightGrey">Name</TableCell>
-            <TableCell className="lightGrey">Port</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>{id}</TableCell>
-            <TableCell>{name}</TableCell>
-            <TableCell>{port}</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    );
-  }
+export default function ChannelDetailsTable(props) {
+  const { channels } = props;
+  return (
+    <Table style={{ margin: "1em", maxWidth: "98%" }} className="flexContents">
+      <TableHead>
+        <ChannelDetailsTableHead />
+      </TableHead>
+      <TableBody>
+        {channels.map((channel) => {
+          return <ChannelDetailsTableRow channel={channel} />;
+        })}
+      </TableBody>
+    </Table>
+  );
 }
 ChannelDetailsTable.propTypes = {
-  channel: PropTypes.oneOfType([
-    PropTypes.instanceOf(InputChannelInfo),
-    PropTypes.instanceOf(OutputChannelInfo)
-  ]).isRequired
+  channels: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.instanceOf(InputChannelInfo),
+      PropTypes.instanceOf(OutputChannelInfo)
+    ])
+  ).isRequired
 };

--- a/frontend/src/devicelist/ChannelDetailsTable.jsx
+++ b/frontend/src/devicelist/ChannelDetailsTable.jsx
@@ -15,7 +15,9 @@ export default function ChannelDetailsTable(props) {
       </TableHead>
       <TableBody>
         {channels.map((channel) => {
-          return <ChannelDetailsTableRow channel={channel} />;
+          return (
+            <ChannelDetailsTableRow channel={channel} key={channel.name} />
+          );
         })}
       </TableBody>
     </Table>

--- a/frontend/src/devicelist/ChannelDetailsTableHead.jsx
+++ b/frontend/src/devicelist/ChannelDetailsTableHead.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableCell, TableHead, TableRow } from "@material-ui/core";
+import { TableCell, TableRow } from "@material-ui/core";
 
 export default function ChannelDetailsTableHead() {
   return (

--- a/frontend/src/devicelist/ChannelDetailsTableHead.jsx
+++ b/frontend/src/devicelist/ChannelDetailsTableHead.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { TableCell, TableHead, TableRow } from "@material-ui/core";
+
+export default function ChannelDetailsTableHead() {
+  return (
+    <TableRow>
+      <TableCell className="lightGrey">ID</TableCell>
+      <TableCell className="lightGrey">Name</TableCell>
+      <TableCell className="lightGrey">Port</TableCell>
+    </TableRow>
+  );
+}

--- a/frontend/src/devicelist/ChannelDetailsTableRow.jsx
+++ b/frontend/src/devicelist/ChannelDetailsTableRow.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { TableCell, TableRow } from "@material-ui/core";
+import PropTypes from "prop-types";
+import InputChannelInfo from "../model/InputChannelInfo";
+import OutputChannelInfo from "../model/OutputChannelInfo";
+
+export default function ChannelDetailsTableRow(props) {
+  const {
+    channel: { id, name, port }
+  } = props;
+  return (
+    <TableRow>
+      <TableCell>{id}</TableCell>
+      <TableCell>{name}</TableCell>
+      <TableCell>{port}</TableCell>
+    </TableRow>
+  );
+}
+ChannelDetailsTableRow.propTypes = {
+  channel: PropTypes.oneOfType([
+    PropTypes.instanceOf(InputChannelInfo),
+    PropTypes.instanceOf(OutputChannelInfo)
+  ]).isRequired
+};

--- a/frontend/src/devicelist/DevicesTable.jsx
+++ b/frontend/src/devicelist/DevicesTable.jsx
@@ -77,14 +77,7 @@ function getDetailPanel() {
           <div className="lightestGrey">
             <Box margin={2}>
               <Typography variant="h6">Channels</Typography>
-              {rowData.channels.map((channel) => {
-                return (
-                  <ChannelDetailsTable
-                    channel={channel}
-                    key={`ch_${channel.id}_p${channel.port}`}
-                  />
-                );
-              })}
+              <ChannelDetailsTable channels={rowData.channels} />
             </Box>
           </div>
         );

--- a/frontend/src/devicelist/__tests__/ChannelDetailsTableHead.test.jsx
+++ b/frontend/src/devicelist/__tests__/ChannelDetailsTableHead.test.jsx
@@ -2,32 +2,31 @@ import React from "react";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 
-import {describe, expect } from "@jest/globals";
+import { describe, expect } from "@jest/globals";
 import { TableCell, TableRow } from "@material-ui/core";
 import ChannelDetailsTableHead from "../ChannelDetailsTableHead";
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe("ChannelDetailsTableHead", () => {
-    let wrapper;
+  let wrapper;
 
-    describe("contains all the correct Components", () => {
-        wrapper = Enzyme.shallow(<ChannelDetailsTableHead />);
-        it("Is one (1) TableRow Component", () => {
-            expect(wrapper.find(TableRow)).toHaveLength(1)
-        })
-        it("Has three (3) TableCell Components", () => {
-            expect(wrapper.find(TableCell)).toHaveLength(3)
-        })
-        it("the first TableCell Component contains \"ID\"", () => {
-            expect(wrapper.childAt(0).text()).toBe("ID");
-        })
-        it("the second TableCell Component contains \"Name\"", () => {
-            expect(wrapper.childAt(1).text()).toBe("Name");
-        })
-        it("the third TableCell Component contains \"port\"", () => {
-            expect(wrapper.childAt(2).text()).toBe("Port");
-        })
-
-    })
-})
+  describe("contains all the correct Components", () => {
+    wrapper = Enzyme.shallow(<ChannelDetailsTableHead />);
+    it("Is one (1) TableRow Component", () => {
+      expect(wrapper.find(TableRow)).toHaveLength(1);
+    });
+    it("Has three (3) TableCell Components", () => {
+      expect(wrapper.find(TableCell)).toHaveLength(3);
+    });
+    it('the first TableCell Component contains "ID"', () => {
+      expect(wrapper.childAt(0).text()).toBe("ID");
+    });
+    it('the second TableCell Component contains "Name"', () => {
+      expect(wrapper.childAt(1).text()).toBe("Name");
+    });
+    it('the third TableCell Component contains "port"', () => {
+      expect(wrapper.childAt(2).text()).toBe("Port");
+    });
+  });
+});

--- a/frontend/src/devicelist/__tests__/ChannelDetailsTableHead.test.jsx
+++ b/frontend/src/devicelist/__tests__/ChannelDetailsTableHead.test.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+import {describe, expect } from "@jest/globals";
+import { TableCell, TableRow } from "@material-ui/core";
+import ChannelDetailsTableHead from "../ChannelDetailsTableHead";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("ChannelDetailsTableHead", () => {
+    let wrapper;
+
+    describe("contains all the correct Components", () => {
+        wrapper = Enzyme.shallow(<ChannelDetailsTableHead />);
+        it("Is one (1) TableRow Component", () => {
+            expect(wrapper.find(TableRow)).toHaveLength(1)
+        })
+        it("Has three (3) TableCell Components", () => {
+            expect(wrapper.find(TableCell)).toHaveLength(3)
+        })
+        it("the first TableCell Component contains \"ID\"", () => {
+            expect(wrapper.childAt(0).text()).toBe("ID");
+        })
+        it("the second TableCell Component contains \"Name\"", () => {
+            expect(wrapper.childAt(1).text()).toBe("Name");
+        })
+        it("the third TableCell Component contains \"port\"", () => {
+            expect(wrapper.childAt(2).text()).toBe("Port");
+        })
+
+    })
+})

--- a/frontend/src/devicelist/__tests__/ChannelDetailsTableRow.test.jsx
+++ b/frontend/src/devicelist/__tests__/ChannelDetailsTableRow.test.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+import { afterEach, describe, expect, jest } from "@jest/globals";
+import { TableCell, TableRow } from "@material-ui/core";
+import InputChannelInfo from "../../model/InputChannelInfo";
+import OutputChannelInfo from "../../model/OutputChannelInfo";
+import ChannelDetailsTableRow from "../ChannelDetailsTableRow";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("ChannelDetailsTableRow", () => {
+    let wrapper;
+    const dummyId = 69;
+    const dummyName = "TEST_NAME";
+    const dummyPort = 1231
+    const inChannel = new InputChannelInfo(dummyId, dummyName, dummyPort, null)
+    const outChannel = new OutputChannelInfo(dummyId, dummyName, dummyPort, null)
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("contains all the correct Components", () => {
+        wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={inChannel} />);
+        it("Is one (1) TableRow Component", () => {
+            expect(wrapper.find(TableRow)).toHaveLength(1)
+        })
+        it("Has three (3) TableCell Components", () => {
+            expect(wrapper.find(TableCell)).toHaveLength(3)
+        })
+        it("the first TableCell Component contains the channel Id", () => {
+            expect(wrapper.childAt(0).text()).toBe(`${dummyId}`);
+        })
+        it("the second TableCell Component contains the channel name", () => {
+            expect(wrapper.childAt(1).text()).toBe(dummyName);
+        })
+        it("the third TableCell Component contains the channel port", () => {
+            expect(wrapper.childAt(2).text()).toBe(`${dummyPort}`);
+        })
+
+    })
+})

--- a/frontend/src/devicelist/__tests__/ChannelDetailsTableRow.test.jsx
+++ b/frontend/src/devicelist/__tests__/ChannelDetailsTableRow.test.jsx
@@ -11,34 +11,33 @@ import ChannelDetailsTableRow from "../ChannelDetailsTableRow";
 Enzyme.configure({ adapter: new Adapter() });
 
 describe("ChannelDetailsTableRow", () => {
-    let wrapper;
-    const dummyId = 69;
-    const dummyName = "TEST_NAME";
-    const dummyPort = 1231
-    const inChannel = new InputChannelInfo(dummyId, dummyName, dummyPort, null)
-    const outChannel = new OutputChannelInfo(dummyId, dummyName, dummyPort, null)
+  let wrapper;
+  const dummyId = 69;
+  const dummyName = "TEST_NAME";
+  const dummyPort = 1231;
+  const inChannel = new InputChannelInfo(dummyId, dummyName, dummyPort, null);
+  const outChannel = new OutputChannelInfo(dummyId, dummyName, dummyPort, null);
 
-    afterEach(() => {
-        jest.clearAllMocks();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("contains all the correct Components", () => {
+    wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={inChannel} />);
+    it("Is one (1) TableRow Component", () => {
+      expect(wrapper.find(TableRow)).toHaveLength(1);
     });
-
-    describe("contains all the correct Components", () => {
-        wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={inChannel} />);
-        it("Is one (1) TableRow Component", () => {
-            expect(wrapper.find(TableRow)).toHaveLength(1)
-        })
-        it("Has three (3) TableCell Components", () => {
-            expect(wrapper.find(TableCell)).toHaveLength(3)
-        })
-        it("the first TableCell Component contains the channel Id", () => {
-            expect(wrapper.childAt(0).text()).toBe(`${dummyId}`);
-        })
-        it("the second TableCell Component contains the channel name", () => {
-            expect(wrapper.childAt(1).text()).toBe(dummyName);
-        })
-        it("the third TableCell Component contains the channel port", () => {
-            expect(wrapper.childAt(2).text()).toBe(`${dummyPort}`);
-        })
-
-    })
-})
+    it("Has three (3) TableCell Components", () => {
+      expect(wrapper.find(TableCell)).toHaveLength(3);
+    });
+    it("the first TableCell Component contains the channel Id", () => {
+      expect(wrapper.childAt(0).text()).toBe(`${dummyId}`);
+    });
+    it("the second TableCell Component contains the channel name", () => {
+      expect(wrapper.childAt(1).text()).toBe(dummyName);
+    });
+    it("the third TableCell Component contains the channel port", () => {
+      expect(wrapper.childAt(2).text()).toBe(`${dummyPort}`);
+    });
+  });
+});

--- a/frontend/src/devicelist/__tests__/ChannelDetailsTableRow.test.jsx
+++ b/frontend/src/devicelist/__tests__/ChannelDetailsTableRow.test.jsx
@@ -9,7 +9,7 @@ import OutputChannelInfo from "../../model/OutputChannelInfo";
 import ChannelDetailsTableRow from "../ChannelDetailsTableRow";
 
 Enzyme.configure({ adapter: new Adapter() });
-
+jest.spyOn(global.console, "error");
 describe("ChannelDetailsTableRow", () => {
   let wrapper;
   const dummyId = 69;
@@ -38,6 +38,25 @@ describe("ChannelDetailsTableRow", () => {
     });
     it("the third TableCell Component contains the channel port", () => {
       expect(wrapper.childAt(2).text()).toBe(`${dummyPort}`);
+    });
+  });
+  describe("Props validation", () => {
+    /*  eslint-disable no-console */
+    it("works with an InputChannelInfo", () => {
+      wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={inChannel} />);
+      expect(wrapper.find(TableRow)).toHaveLength(1);
+      expect(wrapper.find(TableCell)).toHaveLength(3);
+      expect(console.error).not.toHaveBeenCalled();
+    });
+    it("works with an OutputChannelInfo", () => {
+      wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={outChannel} />);
+      expect(wrapper.find(TableRow)).toHaveLength(1);
+      expect(wrapper.find(TableCell)).toHaveLength(3);
+      expect(console.error).not.toHaveBeenCalled();
+    });
+    it("fails if passed an invalid type", () => {
+      wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel="outChannel" />);
+      expect(console.error).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# General info
Cleanup the ChannelDetails table to make building it more elegant. Also add test for the  Channels Details Table

**Issue number**: N/A

**Task description**: 

 - Make Channels a single table instead of one per table
 - Split components into CDTableHead and CDTableBody which are brought together in the CDTable component

 
<!-- What changed? What does this do? Provide screenshots if necessary--> 
| Original   | Updated|
|:---------------:|:---------------:|
![image](https://user-images.githubusercontent.com/35614138/100683905-49df5600-3347-11eb-824c-5a03459cad88.png)|![image](https://user-images.githubusercontent.com/35614138/100683862-3338ff00-3347-11eb-874f-989274c46e22.png)


# Testing

**Test coverage**:

Added actual testing for Channel Details table

# Additional notes

**Note to reviewers**:
<!-- Special instructions for testing this code-->

**To do before merging**:
