### PR TITLE
[#200] Registration bug

### DIFF
--- a/src/main/java/org/beanpod/switchboard/dto/DecoderDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/DecoderDto.java
@@ -28,6 +28,7 @@ public class DecoderDto {
   private Date lastCommunication;
 
   private DeviceDto device;
+
   @JsonIgnoreProperties("decoder")
   private Set<InputChannelDto> input;
 }

--- a/src/main/java/org/beanpod/switchboard/dto/DecoderDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/DecoderDto.java
@@ -9,6 +9,7 @@ import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,11 +18,11 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 @Builder
 public class DecoderDto {
 
-  @NotNull
-  private String serialNumber;
+  @NotNull private String serialNumber;
 
   @Temporal(TemporalType.TIMESTAMP)
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/src/main/java/org/beanpod/switchboard/dto/DecoderDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/DecoderDto.java
@@ -1,7 +1,7 @@
 package org.beanpod.switchboard.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Date;
 import java.util.Set;
 import javax.persistence.Temporal;
@@ -9,24 +9,25 @@ import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Setter
 @Getter
-@EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class DecoderDto {
-  @NotNull private String serialNumber;
+
+  @NotNull
+  private String serialNumber;
 
   @Temporal(TemporalType.TIMESTAMP)
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
   private Date lastCommunication;
 
   private DeviceDto device;
-  @JsonManagedReference private Set<InputChannelDto> input;
+  @JsonIgnoreProperties("decoder")
+  private Set<InputChannelDto> input;
 }

--- a/src/main/java/org/beanpod/switchboard/dto/EncoderDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/EncoderDto.java
@@ -28,6 +28,7 @@ public class EncoderDto {
   private Date lastCommunication;
 
   private DeviceDto device;
+
   @JsonIgnoreProperties("encoder")
   private Set<OutputChannelDto> output;
 }

--- a/src/main/java/org/beanpod/switchboard/dto/EncoderDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/EncoderDto.java
@@ -9,6 +9,7 @@ import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,11 +18,11 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 @Builder
 public class EncoderDto {
 
-  @NotNull
-  private String serialNumber;
+  @NotNull private String serialNumber;
 
   @Temporal(TemporalType.TIMESTAMP)
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")

--- a/src/main/java/org/beanpod/switchboard/dto/EncoderDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/EncoderDto.java
@@ -1,7 +1,7 @@
 package org.beanpod.switchboard.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Date;
 import java.util.Set;
 import javax.persistence.Temporal;
@@ -9,24 +9,25 @@ import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Setter
 @Getter
-@EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class EncoderDto {
-  @NotNull private String serialNumber;
+
+  @NotNull
+  private String serialNumber;
 
   @Temporal(TemporalType.TIMESTAMP)
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
   private Date lastCommunication;
 
   private DeviceDto device;
-  @JsonManagedReference private Set<OutputChannelDto> output;
+  @JsonIgnoreProperties("encoder")
+  private Set<OutputChannelDto> output;
 }

--- a/src/main/java/org/beanpod/switchboard/dto/InputChannelDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/InputChannelDto.java
@@ -1,6 +1,6 @@
 package org.beanpod.switchboard.dto;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +14,10 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 public class InputChannelDto {
-  @NotNull private Long id;
+
+  @NotNull
+  private Long id;
   private ChannelDto channel;
-  @JsonBackReference private DecoderDto decoder;
+  @JsonIgnoreProperties("input")
+  private DecoderDto decoder;
 }

--- a/src/main/java/org/beanpod/switchboard/dto/InputChannelDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/InputChannelDto.java
@@ -18,6 +18,7 @@ public class InputChannelDto {
   @NotNull
   private Long id;
   private ChannelDto channel;
+
   @JsonIgnoreProperties("input")
   private DecoderDto decoder;
 }

--- a/src/main/java/org/beanpod/switchboard/dto/InputChannelDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/InputChannelDto.java
@@ -15,8 +15,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class InputChannelDto {
 
-  @NotNull
-  private Long id;
+  @NotNull private Long id;
   private ChannelDto channel;
 
   @JsonIgnoreProperties("input")

--- a/src/main/java/org/beanpod/switchboard/dto/OutputChannelDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/OutputChannelDto.java
@@ -18,6 +18,7 @@ public class OutputChannelDto {
   @NotNull
   private Long id;
   private ChannelDto channel;
+
   @JsonIgnoreProperties("output")
   private EncoderDto encoder;
 }

--- a/src/main/java/org/beanpod/switchboard/dto/OutputChannelDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/OutputChannelDto.java
@@ -1,6 +1,6 @@
 package org.beanpod.switchboard.dto;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +14,10 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 public class OutputChannelDto {
-  @NotNull private Long id;
+
+  @NotNull
+  private Long id;
   private ChannelDto channel;
-  @JsonBackReference private EncoderDto encoder;
+  @JsonIgnoreProperties("output")
+  private EncoderDto encoder;
 }

--- a/src/main/java/org/beanpod/switchboard/dto/OutputChannelDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/OutputChannelDto.java
@@ -15,8 +15,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class OutputChannelDto {
 
-  @NotNull
-  private Long id;
+  @NotNull private Long id;
   private ChannelDto channel;
 
   @JsonIgnoreProperties("output")

--- a/src/main/java/org/beanpod/switchboard/entity/DecoderEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/DecoderEntity.java
@@ -2,7 +2,6 @@ package org.beanpod.switchboard.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.util.Date;
 import java.util.Set;
 import javax.persistence.CascadeType;
@@ -47,9 +46,9 @@ public class DecoderEntity {
   private DeviceEntity device;
 
   @OneToMany(
-      mappedBy = "decoder",
       fetch = FetchType.LAZY,
-      cascade = {CascadeType.REMOVE})
-  @JsonManagedReference
+      cascade = {CascadeType.ALL})
+  @JoinColumn(name = "decoder_serial")
+  @JsonIgnoreProperties("decoder")
   private Set<InputChannelEntity> input;
 }

--- a/src/main/java/org/beanpod/switchboard/entity/EncoderEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/EncoderEntity.java
@@ -2,7 +2,6 @@ package org.beanpod.switchboard.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.util.Date;
 import java.util.Set;
 import javax.persistence.CascadeType;
@@ -22,13 +21,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 
 @Entity(name = "Encoder")
 @Getter
 @Setter
 @Builder
-@ToString(exclude = {"outputs"})
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(value = {"hibernateLazyIntializer", "handler"})
@@ -50,9 +47,9 @@ public class EncoderEntity {
   private DeviceEntity device;
 
   @OneToMany(
-      mappedBy = "encoder",
       fetch = FetchType.LAZY,
-      cascade = {CascadeType.REMOVE})
-  @JsonManagedReference
+      cascade = {CascadeType.ALL})
+  @JoinColumn(name = "encoder_serial")
+  @JsonIgnoreProperties("encoder")
   private Set<OutputChannelEntity> output;
 }

--- a/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
@@ -30,8 +30,7 @@ public class InputChannelEntity {
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
 
-  @OneToOne(
-      cascade = {CascadeType.MERGE})
+  @OneToOne(cascade = {CascadeType.MERGE})
   @JoinColumn(name = "channel_id")
   private ChannelEntity channel;
 

--- a/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
@@ -31,14 +31,13 @@ public class InputChannelEntity {
   private Long id;
 
   @OneToOne(
-      optional = false,
       cascade = {CascadeType.MERGE})
   @JoinColumn(name = "channel_id")
   private ChannelEntity channel;
 
   @ManyToOne(
       fetch = FetchType.LAZY,
-      cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+      cascade = {CascadeType.MERGE})
   @JoinColumn(name = "decoder_serial")
   @JsonIgnoreProperties("input")
   private DecoderEntity decoder;

--- a/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
@@ -1,6 +1,5 @@
 package org.beanpod.switchboard.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -38,10 +37,9 @@ public class InputChannelEntity {
   private ChannelEntity channel;
 
   @ManyToOne(
-      optional = false,
       fetch = FetchType.LAZY,
-      cascade = {CascadeType.MERGE})
+      cascade = {CascadeType.MERGE, CascadeType.PERSIST})
   @JoinColumn(name = "decoder_serial")
-  @JsonBackReference
+  @JsonIgnoreProperties("input")
   private DecoderEntity decoder;
 }

--- a/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
@@ -30,8 +30,7 @@ public class OutputChannelEntity {
   @Column(name = "id")
   private Long id;
 
-  @OneToOne(
-      cascade = {CascadeType.MERGE})
+  @OneToOne(cascade = {CascadeType.MERGE})
   @JoinColumn(name = "channel_id")
   private ChannelEntity channel;
 

--- a/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
@@ -31,14 +31,13 @@ public class OutputChannelEntity {
   private Long id;
 
   @OneToOne(
-      optional = false,
       cascade = {CascadeType.MERGE})
   @JoinColumn(name = "channel_id")
   private ChannelEntity channel;
 
   @ManyToOne(
       fetch = FetchType.LAZY,
-      cascade = {CascadeType.MERGE, CascadeType.PERSIST})
+      cascade = {CascadeType.MERGE})
   @JoinColumn(name = "encoder_serial")
   @JsonIgnoreProperties("output")
   private EncoderEntity encoder;

--- a/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
@@ -1,6 +1,5 @@
 package org.beanpod.switchboard.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -38,10 +37,9 @@ public class OutputChannelEntity {
   private ChannelEntity channel;
 
   @ManyToOne(
-      optional = false,
       fetch = FetchType.LAZY,
-      cascade = {CascadeType.MERGE})
+      cascade = {CascadeType.MERGE, CascadeType.PERSIST})
   @JoinColumn(name = "encoder_serial")
-  @JsonBackReference
+  @JsonIgnoreProperties("output")
   private EncoderEntity encoder;
 }


### PR DESCRIPTION
# General info

The proper fix is to either do:

1. Only use channel controller to associate encoder/decoder with channels
2. Only use encoder/decoder to persist channels

in that case #1 would be more appropriate since we will be able to associate channels with already existing encoder/decoders with a smaller payload

The fix introduced in this pr, is somewhat a workaround. That allows you do both(persist channels from creatiing an encoder/decoder or persisting channels from the channels entity).

Merge https://github.com/bean-pod/switchboard-samples/pull/8 before merging this pr
**Issue number**: 200

