### PR TITLE
Stop Treating warnings as errors because process.env.CI = true.

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./frontend
 
       - name: Build
-        run: npm run build
+        run: CI=false npm run build
         working-directory: ./frontend
 
       - name: Deploy


### PR DESCRIPTION
# General info
Hotfix to stop treating warnings as errors because process.env.CI = true.

**Issue number**: n/a

**Task description**: 

 - set CI to false during build command

# Testing

**Test coverage**: n/a

# Additional notes

**Note to reviewers**:
[facebook/create-react-app/issues/3657](https://github.com/facebook/create-react-app/issues/3657)

**To do before merging**: n/a
