### PR TITLE
Stop Treating warnings as errors because process.env.CI = true. [2]

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.name $user_name
           git config --global user.email $user_email
           git remote set-url origin https://${github_token}@github.com/${repository}
-          npm run deploy
+          CI=false npm run deploy
         env:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
# General info

I had to set CI=false for deploy command as well.

**Issue number**: n/a

**Task description**: 

 - set CI to false during deploy command

# Testing

**Test coverage**: n/a

# Additional notes

**Note to reviewers**:
Same as #212 

**To do before merging**: n/a
