### PR TITLE
Removed CascadeType.MERGE from channel entities

### DIFF
--- a/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
@@ -35,8 +35,7 @@ public class InputChannelEntity {
   private ChannelEntity channel;
 
   @ManyToOne(
-      fetch = FetchType.LAZY,
-      cascade = {CascadeType.MERGE})
+      fetch = FetchType.LAZY)
   @JoinColumn(name = "decoder_serial")
   @JsonIgnoreProperties("input")
   private DecoderEntity decoder;

--- a/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
@@ -34,8 +34,7 @@ public class InputChannelEntity {
   @JoinColumn(name = "channel_id")
   private ChannelEntity channel;
 
-  @ManyToOne(
-      fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "decoder_serial")
   @JsonIgnoreProperties("input")
   private DecoderEntity decoder;

--- a/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
@@ -34,8 +34,7 @@ public class OutputChannelEntity {
   @JoinColumn(name = "channel_id")
   private ChannelEntity channel;
 
-  @ManyToOne(
-      fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "encoder_serial")
   @JsonIgnoreProperties("output")
   private EncoderEntity encoder;

--- a/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
@@ -35,8 +35,7 @@ public class OutputChannelEntity {
   private ChannelEntity channel;
 
   @ManyToOne(
-      fetch = FetchType.LAZY,
-      cascade = {CascadeType.MERGE})
+      fetch = FetchType.LAZY)
   @JoinColumn(name = "encoder_serial")
   @JsonIgnoreProperties("output")
   private EncoderEntity encoder;


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**:  #242
**Task description**: 

 - Fix an issue where getting the streams of a device fails.
 
<!-- What changed? What does this do? Provide screenshots if necessary--> 

**Original** 
![image](https://user-images.githubusercontent.com/32281260/104823064-5fd0a980-5815-11eb-8edc-24599e51768c.png)

**Updated**
![image](https://user-images.githubusercontent.com/32281260/104823074-68c17b00-5815-11eb-8932-39eb2037aa0e.png)


# Testing

**Test coverage**:
N/A, this could really use an integration test but right now i'm creating this PR as a hotfix to help maxim with #195

# Additional notes

**Note to reviewers**:
Unsure what the impact of removing CascadeType.MERGE is, it doesn't seem to break anything but if someone who has more knowledge than me could confirm that would be awesome.
