### PR TITLE
Add link to device details to actions on device list

### DIFF
--- a/frontend/src/devicelist/ActionMenu.jsx
+++ b/frontend/src/devicelist/ActionMenu.jsx
@@ -50,7 +50,17 @@ export default class ActionMenu extends React.Component {
           anchorOrigin={{ horizontal: "right", vertical: "top" }}
           transformOrigin={{ horizontal: "right", vertical: "top" }}
         >
-          <MenuItem onClick={this.handleClose}>View details</MenuItem>
+          <MenuItem onClick={this.handleClose}>
+            <NavLink
+              to={{
+                pathname: `/Devices/Details/${this.props.device.name}`,
+                state: { device: this.props.device }
+              }}
+              className="invisibleLink"
+            >
+              View Details
+            </NavLink>
+          </MenuItem>
           <MenuItem onClick={this.handleClose}>
             Start stream with this as receiver
           </MenuItem>

--- a/frontend/src/devicelist/ActionMenu.jsx
+++ b/frontend/src/devicelist/ActionMenu.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { NavLink } from "react-router-dom";
 import { IconButton, Menu, MenuItem } from "@material-ui/core";
 
 import { MoreVert } from "@material-ui/icons/";

--- a/frontend/src/devicelist/ActionMenu.jsx
+++ b/frontend/src/devicelist/ActionMenu.jsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
 import { IconButton, Menu, MenuItem } from "@material-ui/core";
+import PropTypes from "prop-types";
 
 import { MoreVert } from "@material-ui/icons/";
+import DeviceInfo from "../model/DeviceInfo";
 
 export default class ActionMenu extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       anchorElement: null
     };
@@ -32,6 +34,7 @@ export default class ActionMenu extends React.Component {
 
   render() {
     const { anchorElement } = this.state;
+    const { device } = this.props;
     return (
       <>
         <IconButton
@@ -54,8 +57,8 @@ export default class ActionMenu extends React.Component {
           <MenuItem onClick={this.handleClose}>
             <NavLink
               to={{
-                pathname: `/Devices/Details/${this.props.device.name}`,
-                state: { device: this.props.device }
+                pathname: `/Devices/Details/${device.name}`,
+                state: { device }
               }}
               className="invisibleLink"
             >
@@ -73,3 +76,7 @@ export default class ActionMenu extends React.Component {
     );
   }
 }
+
+ActionMenu.propTypes = {
+  device: PropTypes.instanceOf(DeviceInfo).isRequired
+};

--- a/frontend/src/devicelist/DevicesTable.jsx
+++ b/frontend/src/devicelist/DevicesTable.jsx
@@ -83,7 +83,7 @@ function getColumnInfo() {
       field: "action",
       filtering: false,
       sorting: false,
-      render: () => <ActionMenu />,
+      render: (rowData) => <ActionMenu device={rowData} />,
       align: "center",
       export: false
     }

--- a/frontend/src/devicelist/__tests__/ActionMenu.test.jsx
+++ b/frontend/src/devicelist/__tests__/ActionMenu.test.jsx
@@ -10,6 +10,7 @@ import {
   it
 } from "@jest/globals";
 import ActionMenu from "../ActionMenu";
+import DeviceInfo from "../../model/DeviceInfo";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -18,7 +19,8 @@ describe("<ActionMenu />", () => {
   let testElement;
 
   beforeEach(() => {
-    wrapper = Enzyme.shallow(<ActionMenu />);
+    const dummyDevice = new DeviceInfo(1, 1, 1, 1, 1, [1, 1], [2, 2]);
+    wrapper = Enzyme.shallow(<ActionMenu device={dummyDevice} />);
   });
   afterEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: N/A

**Task description**: 

 - Added redirect functionality to `View Details` under Actions on the Device List page
 
<!-- What changed? What does this do? Provide screenshots if necessary--> 
| Original   | Updated|
|:---------------:|:---------------:|
| ![image](https://user-images.githubusercontent.com/22307286/104982291-58a5c900-59d8-11eb-9971-fba83e2775b2.png) | ![image](https://user-images.githubusercontent.com/22307286/104982238-3dd35480-59d8-11eb-9637-af6acfbb1033.png) |
| (is not a link) | (is a link) |

# Testing
**Test coverage**:
- N/A

# Additional notes

**Note to reviewers**:
N/A

**To do before merging**:
N/A
