### PR TITLE
[#229] Service logs

### DIFF
--- a/src/main/java/org/beanpod/switchboard/entity/ChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/ChannelEntity.java
@@ -22,7 +22,7 @@ import lombok.Setter;
 public class ChannelEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
   private Long id;
 

--- a/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/InputChannelEntity.java
@@ -27,7 +27,7 @@ import lombok.Setter;
 public class InputChannelEntity {
   @Id
   @NotNull
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @OneToOne(cascade = {CascadeType.MERGE})

--- a/src/main/java/org/beanpod/switchboard/entity/LogEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/LogEntity.java
@@ -20,7 +20,7 @@ import lombok.Setter;
 public class LogEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   private OffsetDateTime dateTime;

--- a/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/OutputChannelEntity.java
@@ -26,7 +26,7 @@ import lombok.Setter;
 @JsonIgnoreProperties({"hibernateLazyIntializer", "handler"})
 public class OutputChannelEntity {
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
   private Long id;
 

--- a/src/main/java/org/beanpod/switchboard/entity/StreamEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/StreamEntity.java
@@ -25,7 +25,7 @@ import lombok.Setter;
 @Builder
 public class StreamEntity {
   @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id")
   private long id;
 

--- a/src/main/java/org/beanpod/switchboard/service/DecoderServiceImpl.java
+++ b/src/main/java/org/beanpod/switchboard/service/DecoderServiceImpl.java
@@ -2,6 +2,7 @@ package org.beanpod.switchboard.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.beanpod.switchboard.dao.DecoderDaoImpl;
 import org.beanpod.switchboard.dao.StreamDaoImpl;
 import org.beanpod.switchboard.dto.DecoderDto;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class DecoderServiceImpl implements DecoderService {
   private final StreamDaoImpl streamDao;
   private final DecoderDaoImpl decoderDao;
@@ -19,6 +21,7 @@ public class DecoderServiceImpl implements DecoderService {
 
   @Override
   public List<StreamDto> getDecoderStreams(String decoderSerialNumber) {
+    log.info("Getting Decoder's {} streams", decoderSerialNumber);
     DecoderDto decoder =
         decoderDao
             .findDecoder(decoderSerialNumber)
@@ -26,6 +29,7 @@ public class DecoderServiceImpl implements DecoderService {
 
     decoder.setLastCommunication(dateUtil.getCurrentDate());
     decoderDao.save(decoder);
+    log.debug("Updating decoder's last communication date");
 
     return streamDao.getDecoderStreams(decoderSerialNumber);
   }

--- a/src/main/java/org/beanpod/switchboard/service/DecoderServiceImpl.java
+++ b/src/main/java/org/beanpod/switchboard/service/DecoderServiceImpl.java
@@ -21,7 +21,7 @@ public class DecoderServiceImpl implements DecoderService {
 
   @Override
   public List<StreamDto> getDecoderStreams(String decoderSerialNumber) {
-    log.info("Getting Decoder's {} streams", decoderSerialNumber);
+    log.info("Getting decoder {} streams", decoderSerialNumber);
     DecoderDto decoder =
         decoderDao
             .findDecoder(decoderSerialNumber)
@@ -29,7 +29,7 @@ public class DecoderServiceImpl implements DecoderService {
 
     decoder.setLastCommunication(dateUtil.getCurrentDate());
     decoderDao.save(decoder);
-    log.debug("Updated decoder's last communication date");
+    log.debug("Updated decoder {} last communication date", decoderSerialNumber);
 
     return streamDao.getDecoderStreams(decoderSerialNumber);
   }

--- a/src/main/java/org/beanpod/switchboard/service/DecoderServiceImpl.java
+++ b/src/main/java/org/beanpod/switchboard/service/DecoderServiceImpl.java
@@ -29,7 +29,7 @@ public class DecoderServiceImpl implements DecoderService {
 
     decoder.setLastCommunication(dateUtil.getCurrentDate());
     decoderDao.save(decoder);
-    log.debug("Updating decoder's last communication date");
+    log.debug("Updated decoder's last communication date");
 
     return streamDao.getDecoderStreams(decoderSerialNumber);
   }

--- a/src/main/java/org/beanpod/switchboard/service/EncoderServiceImpl.java
+++ b/src/main/java/org/beanpod/switchboard/service/EncoderServiceImpl.java
@@ -21,7 +21,7 @@ public class EncoderServiceImpl implements EncoderService {
 
   @Override
   public List<StreamDto> getEncoderStreams(String encoderSerialNumber) {
-    log.info("Getting Encoder's {} streams", encoderSerialNumber);
+    log.info("Getting encoder {} streams", encoderSerialNumber);
     EncoderDto encoderDto =
         encoderDao
             .findEncoder(encoderSerialNumber)
@@ -29,7 +29,7 @@ public class EncoderServiceImpl implements EncoderService {
 
     encoderDto.setLastCommunication(dateUtil.getCurrentDate());
     encoderDao.save(encoderDto);
-    log.debug("Updated encoder's last communication date");
+    log.debug("Updated encoder {} last communication date", encoderSerialNumber);
 
     return streamDao.getEncoderStreams(encoderSerialNumber);
   }

--- a/src/main/java/org/beanpod/switchboard/service/EncoderServiceImpl.java
+++ b/src/main/java/org/beanpod/switchboard/service/EncoderServiceImpl.java
@@ -2,6 +2,7 @@ package org.beanpod.switchboard.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.beanpod.switchboard.dao.EncoderDaoImpl;
 import org.beanpod.switchboard.dao.StreamDaoImpl;
 import org.beanpod.switchboard.dto.EncoderDto;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class EncoderServiceImpl implements EncoderService {
   private final EncoderDaoImpl encoderDao;
   private final StreamDaoImpl streamDao;
@@ -19,6 +21,7 @@ public class EncoderServiceImpl implements EncoderService {
 
   @Override
   public List<StreamDto> getEncoderStreams(String encoderSerialNumber) {
+    log.info("Getting Encoder's {} streams", encoderSerialNumber);
     EncoderDto encoderDto =
         encoderDao
             .findEncoder(encoderSerialNumber)
@@ -26,6 +29,7 @@ public class EncoderServiceImpl implements EncoderService {
 
     encoderDto.setLastCommunication(dateUtil.getCurrentDate());
     encoderDao.save(encoderDto);
+    log.debug("Updated encoder's last communication date");
 
     return streamDao.getEncoderStreams(encoderSerialNumber);
   }

--- a/src/main/java/org/beanpod/switchboard/service/StreamServiceImpl.java
+++ b/src/main/java/org/beanpod/switchboard/service/StreamServiceImpl.java
@@ -24,6 +24,7 @@ public class StreamServiceImpl implements StreamService {
 
   @Override
   public StreamDto createStream(CreateStreamRequest createStreamRequest) {
+
     InputChannelDto inputChannelDto =
         channelDao.getInputChannelById(createStreamRequest.getInputChannelId());
     OutputChannelDto outputChannelDto =

--- a/src/main/java/org/beanpod/switchboard/service/StreamServiceImpl.java
+++ b/src/main/java/org/beanpod/switchboard/service/StreamServiceImpl.java
@@ -1,6 +1,7 @@
 package org.beanpod.switchboard.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.beanpod.switchboard.dao.ChannelDaoImpl;
 import org.beanpod.switchboard.dao.StreamDaoImpl;
 import org.beanpod.switchboard.dto.DeviceDto;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class StreamServiceImpl implements StreamService {
 
   private final StreamDaoImpl streamDao;
@@ -24,6 +26,11 @@ public class StreamServiceImpl implements StreamService {
 
   @Override
   public StreamDto createStream(CreateStreamRequest createStreamRequest) {
+
+    log.info(
+        "Creating a stream request between input channel {} and output channel {}",
+        createStreamRequest.getInputChannelId(),
+        createStreamRequest.getOutputChannelId());
 
     InputChannelDto inputChannelDto =
         channelDao.getInputChannelById(createStreamRequest.getInputChannelId());
@@ -37,20 +44,38 @@ public class StreamServiceImpl implements StreamService {
             .isRendezvous(shouldUseRendezvousMode(inputChannelDto, outputChannelDto))
             .build();
 
-    return streamDao.saveStream(streamDto);
+    StreamDto streamDto1 = streamDao.saveStream(streamDto);
+    log.debug(
+        "Stream created between input channel {} and output channel {}",
+        createStreamRequest.getInputChannelId(),
+        createStreamRequest.getOutputChannelId());
+    return streamDto1;
   }
 
   @Override
   public StreamDto updateStream(StreamDto streamDto) {
+    log.info("Updating stream {}", streamDto.getId());
     StreamEntity updatedStreamEntity = streamDao.updateStream(streamDto);
     return mapper.toDto(updatedStreamEntity);
   }
 
   private boolean shouldUseRendezvousMode(
       InputChannelDto inputChannelDto, OutputChannelDto outputChannelDto) {
+    log.info(
+        "Determining whether to use RendezvousMode between input channel {} and output channel {}",
+        inputChannelDto.getId(),
+        outputChannelDto.getId());
+
     DeviceDto decoderDevice = inputChannelDto.getDecoder().getDevice();
     DeviceDto encoderDevice = outputChannelDto.getEncoder().getDevice();
-    return !(networkingUtil.areDevicesOnSameLocalNetworkAsService(decoderDevice, encoderDevice)
-        || networkingUtil.areDevicesOnSamePrivateNetwork(decoderDevice, encoderDevice));
+    Boolean rendezVousAllowed =
+        !(networkingUtil.areDevicesOnSameLocalNetworkAsService(decoderDevice, encoderDevice)
+            || networkingUtil.areDevicesOnSamePrivateNetwork(decoderDevice, encoderDevice));
+    log.debug(
+        "RendezvousMode is {} between decoder device {} and encoder device {}",
+        Boolean.TRUE.equals(rendezVousAllowed)?"allowed":"not allowed",
+        decoderDevice.getSerialNumber(),
+        encoderDevice.getSerialNumber());
+    return rendezVousAllowed;
   }
 }

--- a/src/main/java/org/beanpod/switchboard/service/StreamServiceImpl.java
+++ b/src/main/java/org/beanpod/switchboard/service/StreamServiceImpl.java
@@ -73,7 +73,7 @@ public class StreamServiceImpl implements StreamService {
             || networkingUtil.areDevicesOnSamePrivateNetwork(decoderDevice, encoderDevice));
     log.debug(
         "RendezvousMode is {} between decoder device {} and encoder device {}",
-        Boolean.TRUE.equals(rendezVousAllowed)?"allowed":"not allowed",
+        Boolean.TRUE.equals(rendezVousAllowed) ? "allowed" : "not allowed",
         decoderDevice.getSerialNumber(),
         encoderDevice.getSerialNumber());
     return rendezVousAllowed;


### PR DESCRIPTION
# General info

- Adds simple logs in the service.
- Generation method of generating IDs has changed to Identity, that will allow when truncating the tables, the IDs to reset to 0 and not continue from the previously persisted value.


If you encounter any errors, make sure to recreate the database.

**Issue number**: 229

