### PR TITLE
Fix for delete device in actions

### DIFF
--- a/frontend/src/api/DeviceApi.js
+++ b/frontend/src/api/DeviceApi.js
@@ -98,9 +98,8 @@ export function getReceivers(callback) {
     });
 }
 
-export function deleteDevice(deviceId, callback) {
-  axios
+export function deleteDevice(deviceId) {
+  return axios
     .delete(`${process.env.REACT_APP_DEVICE}/${deviceId}`)
-    .then(callback)
     .catch(() => {});
 }

--- a/frontend/src/api/DeviceApi.js
+++ b/frontend/src/api/DeviceApi.js
@@ -100,7 +100,7 @@ export function getReceivers(callback) {
 
 export function deleteDevice(deviceId, callback) {
   axios
-    .delete(`REACT_APP_DEVICE=$DOMAIN/device/${deviceId}`)
+    .delete(`${process.env.REACT_APP_DEVICE}/${deviceId}`)
     .then(callback)
     .catch(() => {});
 }

--- a/frontend/src/general/DeleteDeviceButton.jsx
+++ b/frontend/src/general/DeleteDeviceButton.jsx
@@ -38,13 +38,12 @@ export default function DeleteDeviceButton(props) {
     return setOpen(false);
   };
   const confirmDelete = () => {
-    DeviceApi.deleteDevice(deleteId)
-    .then(() => {
-        if(history.location.pathname.endsWith("Devices")) {
-            history.go(0);
-        } else {
-            history.push("/Devices");
-        }
+    DeviceApi.deleteDevice(deleteId).then(() => {
+      if (history.location.pathname.endsWith("Devices")) {
+        history.go(0);
+      } else {
+        history.push("/Devices");
+      }
     });
     return setOpen(false);
   };

--- a/frontend/src/general/DeleteDeviceButton.jsx
+++ b/frontend/src/general/DeleteDeviceButton.jsx
@@ -38,9 +38,14 @@ export default function DeleteDeviceButton(props) {
     return setOpen(false);
   };
   const confirmDelete = () => {
-    DeviceApi.deleteDevice(deleteId);
-    history.push("/Devices");
-    history.go(0);
+    DeviceApi.deleteDevice(deleteId, () => {
+        console.log(history.location)
+        if(history.location.pathname.endsWith("Devices")) {
+            history.go(0);
+        } else {
+            history.push("/Devices");
+        }
+    });
     return setOpen(false);
   };
 

--- a/frontend/src/general/DeleteDeviceButton.jsx
+++ b/frontend/src/general/DeleteDeviceButton.jsx
@@ -38,8 +38,8 @@ export default function DeleteDeviceButton(props) {
     return setOpen(false);
   };
   const confirmDelete = () => {
-    DeviceApi.deleteDevice(deleteId, () => {
-        console.log(history.location)
+    DeviceApi.deleteDevice(deleteId)
+    .then(() => {
         if(history.location.pathname.endsWith("Devices")) {
             history.go(0);
         } else {

--- a/frontend/src/general/__tests__/DeleteDeviceButton.test.jsx
+++ b/frontend/src/general/__tests__/DeleteDeviceButton.test.jsx
@@ -21,7 +21,7 @@ jest.mock("axios");
 const mockHistoryPush = jest.fn();
 const mockHistoryGo = jest.fn();
 const mockHistory = {
-  location: {pathname: null},
+  location: { pathname: null },
   push: mockHistoryPush,
   go: mockHistoryGo
 };
@@ -94,65 +94,65 @@ describe("DeleteButton", () => {
     });
 
     describe("ConfirmButton", () => {
-        describe("on DeviceListPage", () => {
-          it("Should call axios.delete, close the dialog and refresh the page when clicked", async () => {
-            // Pretend we are on the device list page
-            mockHistory.location.pathname = "/Devices";
+      describe("on DeviceListPage", () => {
+        it("Should call axios.delete, close the dialog and refresh the page when clicked", async () => {
+          // Pretend we are on the device list page
+          mockHistory.location.pathname = "/Devices";
 
-            // click the delete button to set open to true
-            wrapper.find("#deleteBtn").simulate("click");
-            expect(setOpen).toBeTruthy;
-    
-            // mock axios before clicking confirm
-            const axiosPromise = Promise.resolve();
-            axios.delete.mockImplementationOnce(() => axiosPromise);
-    
-            // click confirm
-            wrapper.find("#confirmDeleteBtn").simulate("click");
-    
-            // check that axios.delete was called
-            expect(axios.delete).toHaveBeenCalled();
+          // click the delete button to set open to true
+          wrapper.find("#deleteBtn").simulate("click");
+          expect(setOpen).toBeTruthy;
 
-            // Wait for axios promise to finish
-            await flushPromises();
+          // mock axios before clicking confirm
+          const axiosPromise = Promise.resolve();
+          axios.delete.mockImplementationOnce(() => axiosPromise);
 
-            // check that refresh has been called
-            expect(mockHistoryGo).toHaveBeenCalledWith(0);
+          // click confirm
+          wrapper.find("#confirmDeleteBtn").simulate("click");
 
-            // open should be false
-            expect(setOpen).toBeFalsy;
-          });
-        })
+          // check that axios.delete was called
+          expect(axios.delete).toHaveBeenCalled();
 
-        describe("on DeviceDetailsPage", () => {
-          it("Should call axios.delete, close the dialog and redirect to device list page when clicked", async () => {
-            // Pretend we are on the device details page
-            mockHistory.location.pathname = "Devices/Details/sample_sender";
+          // Wait for axios promise to finish
+          await flushPromises();
 
-            // click the delete button to set open to true
-            wrapper.find("#deleteBtn").simulate("click");
-            expect(setOpen).toBeTruthy;
-    
-            // mock axios before clicking confirm
-            const axiosPromise = Promise.resolve();
-            axios.delete.mockImplementationOnce(() => axiosPromise);
-    
-            // click confirm
-            wrapper.find("#confirmDeleteBtn").simulate("click");
-    
-            // check that axios.delete was called
-            expect(axios.delete).toHaveBeenCalled();
+          // check that refresh has been called
+          expect(mockHistoryGo).toHaveBeenCalledWith(0);
 
-            // Wait for axios promise to finish
-            await flushPromises();
+          // open should be false
+          expect(setOpen).toBeFalsy;
+        });
+      });
 
-            // check that redirect has been called
-            expect(mockHistoryPush).toHaveBeenCalledWith("/Devices");
+      describe("on DeviceDetailsPage", () => {
+        it("Should call axios.delete, close the dialog and redirect to device list page when clicked", async () => {
+          // Pretend we are on the device details page
+          mockHistory.location.pathname = "Devices/Details/sample_sender";
 
-            // open should be false
-            expect(setOpen).toBeFalsy;
-          });
-        })
+          // click the delete button to set open to true
+          wrapper.find("#deleteBtn").simulate("click");
+          expect(setOpen).toBeTruthy;
+
+          // mock axios before clicking confirm
+          const axiosPromise = Promise.resolve();
+          axios.delete.mockImplementationOnce(() => axiosPromise);
+
+          // click confirm
+          wrapper.find("#confirmDeleteBtn").simulate("click");
+
+          // check that axios.delete was called
+          expect(axios.delete).toHaveBeenCalled();
+
+          // Wait for axios promise to finish
+          await flushPromises();
+
+          // check that redirect has been called
+          expect(mockHistoryPush).toHaveBeenCalledWith("/Devices");
+
+          // open should be false
+          expect(setOpen).toBeFalsy;
+        });
+      });
     });
   });
 });

--- a/frontend/src/general/__tests__/DeleteDeviceButton.test.jsx
+++ b/frontend/src/general/__tests__/DeleteDeviceButton.test.jsx
@@ -20,12 +20,19 @@ jest.mock("axios");
 
 const mockHistoryPush = jest.fn();
 const mockHistoryGo = jest.fn();
+const mockHistory = {
+  location: {pathname: null},
+  push: mockHistoryPush,
+  go: mockHistoryGo
+};
+
 jest.mock("react-router-dom", () => ({
-  useHistory: () => ({
-    push: mockHistoryPush,
-    go: mockHistoryGo
-  })
+  useHistory: () => {
+    return mockHistory;
+  }
 }));
+
+const flushPromises = () => new Promise(setImmediate);
 
 describe("DeleteButton", () => {
   let wrapper;
@@ -87,27 +94,65 @@ describe("DeleteButton", () => {
     });
 
     describe("ConfirmButton", () => {
-      it("Should call axios.delete and close the dialog when clicked", () => {
-        // click the delete button to set open to true
-        wrapper.find("#deleteBtn").simulate("click");
-        expect(setOpen).toBeTruthy;
+        describe("on DeviceListPage", () => {
+          it("Should call axios.delete, close the dialog and refresh the page when clicked", async () => {
+            // Pretend we are on the device list page
+            mockHistory.location.pathname = "/Devices";
 
-        // mock axios before clicking confirm
-        axios.delete.mockImplementationOnce(() => Promise.resolve());
+            // click the delete button to set open to true
+            wrapper.find("#deleteBtn").simulate("click");
+            expect(setOpen).toBeTruthy;
+    
+            // mock axios before clicking confirm
+            const axiosPromise = Promise.resolve();
+            axios.delete.mockImplementationOnce(() => axiosPromise);
+    
+            // click confirm
+            wrapper.find("#confirmDeleteBtn").simulate("click");
+    
+            // check that axios.delete was called
+            expect(axios.delete).toHaveBeenCalled();
 
-        // click confirm
-        wrapper.find("#confirmDeleteBtn").simulate("click");
+            // Wait for axios promise to finish
+            await flushPromises();
 
-        // check that axios.delete was called
-        expect(axios.delete).toHaveBeenCalled();
+            // check that refresh has been called
+            expect(mockHistoryGo).toHaveBeenCalledWith(0);
 
-        // check that redirect/refresh has been called
-        expect(mockHistoryPush).toHaveBeenCalledWith("/Devices");
-        expect(mockHistoryGo).toHaveBeenCalledWith(0);
+            // open should be false
+            expect(setOpen).toBeFalsy;
+          });
+        })
 
-        // open should be false
-        expect(setOpen).toBeFalsy;
-      });
+        describe("on DeviceDetailsPage", () => {
+          it("Should call axios.delete, close the dialog and redirect to device list page when clicked", async () => {
+            // Pretend we are on the device details page
+            mockHistory.location.pathname = "Devices/Details/sample_sender";
+
+            // click the delete button to set open to true
+            wrapper.find("#deleteBtn").simulate("click");
+            expect(setOpen).toBeTruthy;
+    
+            // mock axios before clicking confirm
+            const axiosPromise = Promise.resolve();
+            axios.delete.mockImplementationOnce(() => axiosPromise);
+    
+            // click confirm
+            wrapper.find("#confirmDeleteBtn").simulate("click");
+    
+            // check that axios.delete was called
+            expect(axios.delete).toHaveBeenCalled();
+
+            // Wait for axios promise to finish
+            await flushPromises();
+
+            // check that redirect has been called
+            expect(mockHistoryPush).toHaveBeenCalledWith("/Devices");
+
+            // open should be false
+            expect(setOpen).toBeFalsy;
+          });
+        })
     });
   });
 });


### PR DESCRIPTION
@gdzooks This is a PR into your branch so you can review my fix

* Fixed URL of delete axios request to use environment variables
* Delayed redirect/refresh until a response is received from the server in order to ensure the delete call gets sent & that the device is deleted before we refresh.
* Added a conditional making it so if we are on the device details page, we redirect to the device list page, but if we are on the device list page, we refresh the page. This avoided an issue where it was refreshing twice with my fix when deleting on device list page (one redirect + one refresh)
