### PR TITLE
[#217] Get logs of a specific device - updated PR

### DIFF
--- a/contracts/api-spec.yaml
+++ b/contracts/api-spec.yaml
@@ -10,6 +10,19 @@ servers:
     description: Local Enviorment
 
 paths:
+  /logs/{serialNumber}:
+    get:
+      operationId: retrieveDeviceLogs
+      description: Get a list of logs for a specific device
+      parameters:
+        - $ref: '#/components/parameters/DeviceSerialNumber'
+      responses:
+        '200':
+          description: Succesful retrieval of the device logs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogsModel'
   /logs:
     get:
       operationId: retrieveAllLogs

--- a/src/main/java/org/beanpod/switchboard/aop/DeviceAspect.java
+++ b/src/main/java/org/beanpod/switchboard/aop/DeviceAspect.java
@@ -34,7 +34,7 @@ public class DeviceAspect {
       message = message.concat(" with status " + status);
     }
 
-    logService.createLog(message, "info");
+    logService.createLog(message, "info", serialNumber);
   }
 
   @AfterReturning(
@@ -48,7 +48,7 @@ public class DeviceAspect {
 
     if (status.equals("online") || status.equals("offline")) {
       message = "A device has been updated with a status of " + status;
-      logService.createLog(message, "info");
+      logService.createLog(message, "info", deviceModel.getSerialNumber());
     }
   }
 }

--- a/src/main/java/org/beanpod/switchboard/aop/StreamAspect.java
+++ b/src/main/java/org/beanpod/switchboard/aop/StreamAspect.java
@@ -65,7 +65,7 @@ public class StreamAspect {
             "A stream started from output channel %d of decoder %s"
                 + " to input channel %d of encoder %s",
             outputId, decoderSerial, inputId, encoderSerial);
-    logService.createLog(message, "info");
+    logService.createLog(message, "info", decoderSerial + "," + encoderSerial);
   }
 
   @Before("execution(* org.beanpod.switchboard.controller.StreamController.deleteStream(..))")
@@ -79,6 +79,6 @@ public class StreamAspect {
         String.format(
             "Deleted stream of ID %d between decoder %s and encoder %s",
             streamId, decoderSerial, encoderSerial);
-    logService.createLog(message, "info");
+    logService.createLog(message, "info", decoderSerial + "," + encoderSerial);
   }
 }

--- a/src/main/java/org/beanpod/switchboard/controller/LogController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/LogController.java
@@ -18,4 +18,9 @@ public class LogController implements LogsApi {
   public ResponseEntity<List<LogModel>> retrieveAllLogs() {
     return ResponseEntity.ok(logDao.getLogs());
   }
+
+  @Override
+  public ResponseEntity<List<LogModel>> retrieveDeviceLogs(@PathVariable String serialNumber) {
+    return ResponseEntity.ok(logDao.getDeviceLogs(serialNumber));
+  }
 }

--- a/src/main/java/org/beanpod/switchboard/controller/LogController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/LogController.java
@@ -1,5 +1,6 @@
 package org.beanpod.switchboard.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.beanpod.switchboard.dao.LogDaoImpl;
 import org.openapitools.api.LogsApi;
@@ -7,8 +8,6 @@ import org.openapitools.model.LogModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/org/beanpod/switchboard/controller/LogController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/LogController.java
@@ -1,12 +1,14 @@
 package org.beanpod.switchboard.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.beanpod.switchboard.dao.LogDaoImpl;
 import org.openapitools.api.LogsApi;
 import org.openapitools.model.LogModel;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
+++ b/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
@@ -17,4 +17,8 @@ public class LogDaoImpl {
   public List<LogModel> getLogs() {
     return logMapper.toLogModels(logRepository.findAll());
   }
+
+  public List<LogModel> getDeviceLogs(String serialNumber) {
+    return logMapper.toLogModels(logRepository.findBySerialNumber(serialNumber));
+  }
 }

--- a/src/main/java/org/beanpod/switchboard/dto/LogDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/LogDto.java
@@ -1,8 +1,11 @@
 package org.beanpod.switchboard.dto;
 
-import lombok.*;
-
 import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
 @Setter
 @Getter

--- a/src/main/java/org/beanpod/switchboard/dto/LogDto.java
+++ b/src/main/java/org/beanpod/switchboard/dto/LogDto.java
@@ -1,11 +1,8 @@
 package org.beanpod.switchboard.dto;
 
+import lombok.*;
+
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 
 @Setter
 @Getter
@@ -21,4 +18,6 @@ public class LogDto {
   private String message;
 
   private String level;
+
+  private String serialNumber;
 }

--- a/src/main/java/org/beanpod/switchboard/entity/LogEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/LogEntity.java
@@ -27,5 +27,5 @@ public class LogEntity {
   private String level;
 
   private String
-          serialNumber; // This can be a single serialNumber or two serialNumbers seperated by a comma
+      serialNumber; // This can be a single serialNumber or two serialNumbers seperated by a comma
 }

--- a/src/main/java/org/beanpod/switchboard/entity/LogEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/LogEntity.java
@@ -1,12 +1,15 @@
 package org.beanpod.switchboard.entity;
 
-import lombok.*;
-
+import java.time.OffsetDateTime;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Builder

--- a/src/main/java/org/beanpod/switchboard/entity/LogEntity.java
+++ b/src/main/java/org/beanpod/switchboard/entity/LogEntity.java
@@ -1,15 +1,12 @@
 package org.beanpod.switchboard.entity;
 
-import java.time.OffsetDateTime;
+import lombok.*;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import java.time.OffsetDateTime;
 
 @Entity
 @Builder
@@ -28,4 +25,7 @@ public class LogEntity {
   private String message;
 
   private String level;
+
+  private String
+          serialNumber; // This can be a single serialNumber or two serialNumbers seperated by a comma
 }

--- a/src/main/java/org/beanpod/switchboard/repository/LogRepository.java
+++ b/src/main/java/org/beanpod/switchboard/repository/LogRepository.java
@@ -1,11 +1,10 @@
 package org.beanpod.switchboard.repository;
 
+import java.util.List;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface LogRepository extends JpaRepository<LogEntity, Long> {

--- a/src/main/java/org/beanpod/switchboard/repository/LogRepository.java
+++ b/src/main/java/org/beanpod/switchboard/repository/LogRepository.java
@@ -1,9 +1,11 @@
 package org.beanpod.switchboard.repository;
 
-import java.util.List;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface LogRepository extends JpaRepository<LogEntity, Long> {
@@ -11,4 +13,9 @@ public interface LogRepository extends JpaRepository<LogEntity, Long> {
   LogEntity save(LogEntity logEntity);
 
   List<LogEntity> findAll();
+
+  // The Query covers three cases: 1- serialNumber = X,Y 2- serialNumber = Y,X 3- serialNumber = X
+  @Query(
+          "SELECT l FROM LogEntity l WHERE l.serialNumber LIKE CONCAT(?1,',%') OR l.serialNumber LIKE CONCAT('%,',?1) OR l.serialNumber = ?1")
+  List<LogEntity> findBySerialNumber(String serialNumber);
 }

--- a/src/main/java/org/beanpod/switchboard/repository/LogRepository.java
+++ b/src/main/java/org/beanpod/switchboard/repository/LogRepository.java
@@ -15,6 +15,7 @@ public interface LogRepository extends JpaRepository<LogEntity, Long> {
 
   // The Query covers three cases: 1- serialNumber = X,Y 2- serialNumber = Y,X 3- serialNumber = X
   @Query(
-      "SELECT l FROM LogEntity l WHERE l.serialNumber LIKE CONCAT(?1,',%') OR l.serialNumber LIKE CONCAT('%,',?1) OR l.serialNumber = ?1")
+      "SELECT l FROM LogEntity l WHERE l.serialNumber LIKE CONCAT(?1,',%') "
+          + "OR l.serialNumber LIKE CONCAT('%,',?1) OR l.serialNumber = ?1")
   List<LogEntity> findBySerialNumber(String serialNumber);
 }

--- a/src/main/java/org/beanpod/switchboard/repository/LogRepository.java
+++ b/src/main/java/org/beanpod/switchboard/repository/LogRepository.java
@@ -16,6 +16,6 @@ public interface LogRepository extends JpaRepository<LogEntity, Long> {
 
   // The Query covers three cases: 1- serialNumber = X,Y 2- serialNumber = Y,X 3- serialNumber = X
   @Query(
-          "SELECT l FROM LogEntity l WHERE l.serialNumber LIKE CONCAT(?1,',%') OR l.serialNumber LIKE CONCAT('%,',?1) OR l.serialNumber = ?1")
+      "SELECT l FROM LogEntity l WHERE l.serialNumber LIKE CONCAT(?1,',%') OR l.serialNumber LIKE CONCAT('%,',?1) OR l.serialNumber = ?1")
   List<LogEntity> findBySerialNumber(String serialNumber);
 }

--- a/src/main/java/org/beanpod/switchboard/service/LogService.java
+++ b/src/main/java/org/beanpod/switchboard/service/LogService.java
@@ -1,12 +1,11 @@
 package org.beanpod.switchboard.service;
 
+import java.time.OffsetDateTime;
 import lombok.RequiredArgsConstructor;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.beanpod.switchboard.repository.LogRepository;
 import org.beanpod.switchboard.util.DateUtil;
 import org.springframework.stereotype.Component;
-
-import java.time.OffsetDateTime;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/org/beanpod/switchboard/service/LogService.java
+++ b/src/main/java/org/beanpod/switchboard/service/LogService.java
@@ -1,11 +1,12 @@
 package org.beanpod.switchboard.service;
 
-import java.time.OffsetDateTime;
 import lombok.RequiredArgsConstructor;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.beanpod.switchboard.repository.LogRepository;
 import org.beanpod.switchboard.util.DateUtil;
 import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -14,10 +15,15 @@ public class LogService {
   private final DateUtil dateUtil;
   private final LogRepository logRepository;
 
-  public void createLog(String message, String level) {
+  public void createLog(String message, String level, String serialNumber) {
 
     LogEntity logEntity =
-        LogEntity.builder().message(message).level(level).dateTime(OffsetDateTime.now()).build();
+            LogEntity.builder()
+                    .message(message)
+                    .level(level)
+                    .dateTime(OffsetDateTime.now())
+                    .serialNumber(serialNumber)
+                    .build();
     logRepository.save(logEntity);
   }
 }

--- a/src/main/java/org/beanpod/switchboard/service/LogService.java
+++ b/src/main/java/org/beanpod/switchboard/service/LogService.java
@@ -18,12 +18,12 @@ public class LogService {
   public void createLog(String message, String level, String serialNumber) {
 
     LogEntity logEntity =
-            LogEntity.builder()
-                    .message(message)
-                    .level(level)
-                    .dateTime(OffsetDateTime.now())
-                    .serialNumber(serialNumber)
-                    .build();
+        LogEntity.builder()
+            .message(message)
+            .level(level)
+            .dateTime(OffsetDateTime.now())
+            .serialNumber(serialNumber)
+            .build();
     logRepository.save(logEntity);
   }
 }

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -1,10 +1,5 @@
 package org.beanpod.switchboard.controller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
 import org.beanpod.switchboard.dao.LogDaoImpl;
 import org.beanpod.switchboard.fixture.LogFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +10,12 @@ import org.mockito.MockitoAnnotations;
 import org.openapitools.model.LogModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.Mockito.when;
 
 class LogControllerTest {
 
@@ -36,6 +37,14 @@ class LogControllerTest {
   final void testRetrieveAllLogs() {
     when(logDao.getLogs()).thenReturn(logModels);
     ResponseEntity<List<LogModel>> response = logController.retrieveAllLogs();
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertIterableEquals(logModels, response.getBody());
+  }
+
+  @Test
+  final void testRetrieveDeviceLogs() {
+    when(logDao.getDeviceLogs("1")).thenReturn(logModels);
+    ResponseEntity<List<LogModel>> response = logController.retrieveDeviceLogs("1");
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertIterableEquals(logModels, response.getBody());
   }

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -1,5 +1,10 @@
 package org.beanpod.switchboard.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
 import org.beanpod.switchboard.dao.LogDaoImpl;
 import org.beanpod.switchboard.fixture.LogFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,12 +15,6 @@ import org.mockito.MockitoAnnotations;
 import org.openapitools.model.LogModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.mockito.Mockito.when;
 
 class LogControllerTest {
 

--- a/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
+++ b/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
@@ -1,12 +1,8 @@
 package org.beanpod.switchboard.dao;
 
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.entity.LogEntity;
+import org.beanpod.switchboard.fixture.DeviceFixture;
 import org.beanpod.switchboard.fixture.LogFixture;
 import org.beanpod.switchboard.repository.LogRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +11,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.openapitools.model.LogModel;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 class LogDaoImplTest {
   public static List<LogModel> logModels;
@@ -40,6 +42,14 @@ class LogDaoImplTest {
     when(logRepository.findAll()).thenReturn(logEntities);
     when(logMapper.toLogModels(any())).thenReturn(logModels);
     List<LogModel> logs = logDao.getLogs();
+    assertIterableEquals(logModels, logs);
+  }
+
+  @Test
+  final void testGetDeviceLogs() {
+    when(logRepository.findBySerialNumber(DeviceFixture.SERIAL_NUMBER)).thenReturn(logEntities);
+    when(logMapper.toLogModels(any())).thenReturn(logModels);
+    List<LogModel> logs = logDao.getDeviceLogs(DeviceFixture.SERIAL_NUMBER);
     assertIterableEquals(logModels, logs);
   }
 }

--- a/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
+++ b/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
@@ -1,12 +1,13 @@
 package org.beanpod.switchboard.fixture;
 
+import org.beanpod.switchboard.entity.LogEntity;
+import org.openapitools.model.LogModel;
+
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import org.beanpod.switchboard.entity.LogEntity;
-import org.openapitools.model.LogModel;
 
 public class LogFixture {
 
@@ -21,7 +22,13 @@ public class LogFixture {
   }
 
   public static LogEntity getLogEntity() {
-    return LogEntity.builder().id(id).dateTime(dateTime).message(message).level(level).build();
+    return LogEntity.builder()
+        .id(id)
+        .dateTime(dateTime)
+        .message(message)
+        .level(level)
+        .serialNumber(DeviceFixture.SERIAL_NUMBER)
+        .build();
   }
 
   public static List<LogModel> getListOfLogs() {

--- a/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
+++ b/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
@@ -1,13 +1,12 @@
 package org.beanpod.switchboard.fixture;
 
-import org.beanpod.switchboard.entity.LogEntity;
-import org.openapitools.model.LogModel;
-
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import org.beanpod.switchboard.entity.LogEntity;
+import org.openapitools.model.LogModel;
 
 public class LogFixture {
 

--- a/src/test/java/org/beanpod/switchboard/service/LogServiceTest.java
+++ b/src/test/java/org/beanpod/switchboard/service/LogServiceTest.java
@@ -1,12 +1,8 @@
 package org.beanpod.switchboard.service;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.entity.LogEntity;
+import org.beanpod.switchboard.fixture.DeviceFixture;
 import org.beanpod.switchboard.fixture.LogFixture;
 import org.beanpod.switchboard.repository.LogRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 class LogServiceTest {
 
@@ -36,7 +35,7 @@ class LogServiceTest {
   @Test
   final void testGetLog() {
     when(logRepository.save(any())).thenReturn(logEntity);
-    logService.createLog("im a log", "info");
+    logService.createLog("im a log", "info", DeviceFixture.SERIAL_NUMBER);
     verify(logRepository, times(1)).save(any());
   }
 }

--- a/src/test/java/org/beanpod/switchboard/service/LogServiceTest.java
+++ b/src/test/java/org/beanpod/switchboard/service/LogServiceTest.java
@@ -1,5 +1,10 @@
 package org.beanpod.switchboard.service;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.beanpod.switchboard.fixture.DeviceFixture;
@@ -10,9 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 class LogServiceTest {
 


### PR DESCRIPTION
**Issue number**: Closes #217 

**Task description**: 

- Added an endpoint to retrieve the logs of a specific device
- Added a unit test for the controller

# Additional notes

Assuming that the device serial number that we would like to find the logs for is X, serial_number attribute in LogEntity can be populated as one the following three cases: 1- X 2- X,Y, 3-Y,X.

The first case appears after creating and updating a device.
The last two cases appear after creating a stream since we have encoder and decoder (not only a single device).
