### PR TITLE
Suppress 'Missing a Javadoc comment' violations for all lines and files

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+  <!--
+    directs a SuppressionFilter to reject
+    'Missing a Javadoc comment' violations for all lines and files
+   -->
+  <suppress message="Missing a Javadoc comment"/>
+</suppressions>


### PR DESCRIPTION
# General info
Suppress 'Missing a Javadoc comment' violations for all lines and files

**Issue number**: n/a

**Task description**: 

 - Suppress 'Missing a Javadoc comment' violations for all lines and files

# Testing

**Test coverage**: n/a

# Additional notes

**Note to reviewers**:
Once merged, all code smells related to 'Missing a Javadoc comment' will be suppressed in our SonarCloud analysis.

**To do before merging**: n/a
