### PR TITLE
[#309] Fixed most frontend code smells

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5275,6 +5275,12 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
+      "dev": true
+    },
     "cssnano": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
@@ -9321,6 +9327,16 @@
         }
       }
     },
+    "jest-canvas-mock": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz",
+      "integrity": "sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "jest-changed-files": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
@@ -12571,6 +12587,23 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
       "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
+    "moo-color": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.2.tgz",
+      "integrity": "sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -17959,7 +17992,6 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -17977,7 +18009,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -18008,7 +18039,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -18020,7 +18050,6 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -18071,7 +18100,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -18080,7 +18108,6 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -18097,7 +18124,6 @@
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -18143,8 +18169,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "string_decoder": {
           "version": "1.1.1",
@@ -18159,7 +18184,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5278,8 +5278,7 @@
     "cssfontparser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
-      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
-      "dev": true
+      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M="
     },
     "cssnano": {
       "version": "4.1.10",
@@ -9331,7 +9330,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.1.tgz",
       "integrity": "sha512-5FnSZPrX3Q2ZfsbYNE3wqKR3+XorN8qFzDzB5o0golWgt6EOX1+emBnpOc9IAQ+NXFj8Nzm3h7ZdE/9H0ylBcg==",
-      "dev": true,
       "requires": {
         "cssfontparser": "^1.2.1",
         "moo-color": "^1.0.2"
@@ -12592,7 +12590,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.2.tgz",
       "integrity": "sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==",
-      "dev": true,
       "requires": {
         "color-name": "^1.1.4"
       },
@@ -12600,8 +12597,7 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         }
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "axios": "^0.21.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
+    "jest-canvas-mock": "^2.3.1",
     "jest-sonar-reporter": "^1.3.0",
     "material-table": "^1.69.2",
     "prop-types": "^15.7.2",
@@ -140,7 +141,6 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "gh-pages": "^3.1.0",
-    "jest-canvas-mock": "^2.3.1",
     "prettier": "^2.1.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -140,6 +140,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "gh-pages": "^3.1.0",
+    "jest-canvas-mock": "^2.3.1",
     "prettier": "^2.1.2"
   }
 }

--- a/frontend/src/__tests__/HeaderBar.test.jsx
+++ b/frontend/src/__tests__/HeaderBar.test.jsx
@@ -2,17 +2,11 @@ import React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 import { act } from "react-dom/test-utils";
 import { BrowserRouter } from "react-router-dom";
-import { makeStyles } from "@material-ui/core";
 
 import { afterEach, beforeEach, expect, test } from "@jest/globals";
 import HeaderBar from "../general/HeaderBar";
 
 let container = null;
-const expectedTheme = makeStyles((theme) => ({
-  menuButton: {
-    marginRight: theme.spacing(2)
-  }
-}));
 
 beforeEach(() => {
   container = document.createElement("div");

--- a/frontend/src/api/DeviceApi.js
+++ b/frontend/src/api/DeviceApi.js
@@ -53,7 +53,7 @@ export function getSenders(callback) {
         })
       );
     })
-    .catch((error) => {
+    .catch(() => {
       SampleData.getSenders(callback);
     });
 }
@@ -93,7 +93,7 @@ export function getReceivers(callback) {
         })
       );
     })
-    .catch((error) => {
+    .catch(() => {
       SampleData.getReceivers(callback);
     });
 }

--- a/frontend/src/api/StreamApi.js
+++ b/frontend/src/api/StreamApi.js
@@ -3,21 +3,6 @@ import { convertToDataObject } from "../model/ConvertDataFormat";
 import StreamInfo from "../model/StreamInfo";
 import * as SampleData from "./SampleData";
 
-export function getAllStreams(callback) {
-  axios
-    .get(process.env.REACT_APP_STREAM)
-    .then((streams) => {
-      Promise.all(
-        streams.data.map((streamId) => {
-          return getStream(streamId);
-        })
-      ).then(callback);
-    })
-    .catch((error) => {
-      SampleData.getAllStreams(callback);
-    });
-}
-
 export function getStream(streamId) {
   return new Promise((resolve, reject) => {
     axios
@@ -35,6 +20,21 @@ export function getStream(streamId) {
       })
       .catch(reject);
   });
+}
+
+export function getAllStreams(callback) {
+  axios
+    .get(process.env.REACT_APP_STREAM)
+    .then((streams) => {
+      Promise.all(
+        streams.data.map((streamId) => {
+          return getStream(streamId);
+        })
+      ).then(callback);
+    })
+    .catch(() => {
+      SampleData.getAllStreams(callback);
+    });
 }
 
 export function deleteStream(streamId, callback) {

--- a/frontend/src/api/tests/DeviceApi.test.js
+++ b/frontend/src/api/tests/DeviceApi.test.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import * as SampleData from "../SampleData";
 import * as DeviceApi from "../DeviceApi";
 import * as DeviceFixture from "./DeviceFixture";
 

--- a/frontend/src/api/tests/StreamApi.test.js
+++ b/frontend/src/api/tests/StreamApi.test.js
@@ -46,7 +46,7 @@ describe("Stream Api", () => {
     it("should call axios.get and return an array of streams", () => {
       axios.get.mockResolvedValue(mockStreams);
 
-      StreamApi.getAllStreams();
+      StreamApi.getAllStreams(() => {});
 
       expect(axios.get).toHaveBeenCalledWith("http://localhost:8080/stream");
     });

--- a/frontend/src/api/tests/StreamApi.test.js
+++ b/frontend/src/api/tests/StreamApi.test.js
@@ -1,4 +1,3 @@
-import React from "react";
 import axios from "axios";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";

--- a/frontend/src/createStream/SelectDevicesTable.jsx
+++ b/frontend/src/createStream/SelectDevicesTable.jsx
@@ -6,30 +6,29 @@ import SearchBar from "./SearchBar";
 import SelectDeviceTableRow from "./SelectDeviceTableRow";
 import DeviceInfo from "../model/DeviceInfo";
 
-export default class SelectDevicesTable extends React.Component {
-  render() {
-    const { dataSource, name, onChange } = this.props;
-    return (
-      <>
-        <div className="subtitle">{name}</div>
-        <SearchBar />
-        <div style={{ maxHeight: "300px", overflow: "auto" }}>
-          <List>
-            {dataSource.map((device) => {
-              return (
-                <SelectDeviceTableRow
-                  deviceDetails={device}
-                  key={device.serialNumber}
-                  onChange={onChange}
-                />
-              );
-            })}
-          </List>
-        </div>
-      </>
-    );
-  }
+export default function SelectDevicesTable(props) {
+  const { dataSource, name, onChange } = props;
+  return (
+    <>
+      <div className="subtitle">{name}</div>
+      <SearchBar />
+      <div style={{ maxHeight: "300px", overflow: "auto" }}>
+        <List>
+          {dataSource.map((device) => {
+            return (
+              <SelectDeviceTableRow
+                deviceDetails={device}
+                key={device.serialNumber}
+                onChange={onChange}
+              />
+            );
+          })}
+        </List>
+      </div>
+    </>
+  );
 }
+
 SelectDevicesTable.propTypes = {
   name: PropTypes.string.isRequired,
   dataSource: PropTypes.arrayOf(PropTypes.instanceOf(DeviceInfo)).isRequired,

--- a/frontend/src/createStream/__tests__/StreamingPage.test.jsx
+++ b/frontend/src/createStream/__tests__/StreamingPage.test.jsx
@@ -13,7 +13,6 @@ import SelectDeviceTableRow from "../SelectDeviceTableRow";
 
 let container = null;
 let sampleSenders = null;
-let sampleReceivers = null;
 
 beforeEach(() => {
   container = document.createElement("div");
@@ -22,9 +21,6 @@ beforeEach(() => {
   // Get sample data for the purpose of asserting
   SampleData.getSenders((senders) => {
     sampleSenders = senders;
-  });
-  SampleData.getReceivers((receivers) => {
-    sampleReceivers = receivers;
   });
 });
 

--- a/frontend/src/createStream/__tests__/StreamingTable.test.jsx
+++ b/frontend/src/createStream/__tests__/StreamingTable.test.jsx
@@ -17,23 +17,23 @@ Enzyme.configure({ adapter: new Adapter() });
 jest.mock("axios");
 jest.spyOn(global.console, "log");
 
-class DummyData {
+const DummyData = {
   getSenders() {
     return ["A", "B", "C"];
-  }
+  },
 
   getReceivers() {
     return ["X", "Y", "Z"];
-  }
+  },
 
   preventDefault() {}
-}
+};
 
 describe("<StreamingTable/>", () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = Enzyme.shallow(<StreamingTable dataSource={new DummyData()} />);
+    wrapper = Enzyme.shallow(<StreamingTable dataSource={DummyData} />);
   });
 
   afterEach(() => {
@@ -109,7 +109,7 @@ describe("<StreamingTable/>", () => {
       };
       axios.post.mockImplementationOnce(() => Promise.resolve(data));
       // act
-      wrapper.instance().handleSubmit(new DummyData());
+      wrapper.instance().handleSubmit(DummyData);
       expect(axios.post).not.toHaveBeenCalled();
     });
     it("should do nothing if a receiver but no sender has been selected", () => {
@@ -128,7 +128,7 @@ describe("<StreamingTable/>", () => {
       // act
       wrapper.instance().onReceiverSelected(mockReceiver);
 
-      wrapper.instance().handleSubmit(new DummyData());
+      wrapper.instance().handleSubmit(DummyData);
       expect(axios.post).not.toHaveBeenCalled();
     });
     it("should do nothing if no receiver but a sender has been selected", () => {
@@ -145,7 +145,7 @@ describe("<StreamingTable/>", () => {
 
       // act
       wrapper.instance().onSenderSelected(mockSender);
-      wrapper.instance().handleSubmit(new DummyData());
+      wrapper.instance().handleSubmit(DummyData);
       expect(axios.post).not.toHaveBeenCalled();
     });
     it("should call axios.post if a sender and a receiver have been selected", () => {
@@ -175,7 +175,7 @@ describe("<StreamingTable/>", () => {
       wrapper.instance().onSenderSelected(mockSender);
       wrapper.instance().onReceiverSelected(mockReceiver);
 
-      wrapper.instance().handleSubmit(new DummyData());
+      wrapper.instance().handleSubmit(DummyData);
 
       expect(axios.post).toHaveBeenCalledWith(
         "http://localhost:8080/stream",

--- a/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsConciseRow.test.jsx
+++ b/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsConciseRow.test.jsx
@@ -120,21 +120,6 @@ describe("DeviceDetailsConciseRow class", () => {
       );
       expect(wrapper.find(TableContainer)).toHaveLength(1);
     });
-    it("Throws an error when using value that is not an array of ChannelInfo objects", () => {
-      const dummyValue = "badValue";
-      wrapper = Enzyme.shallow(
-        <DeviceDetailsConciseRow name="Test_Name" value={dummyValue} />
-      );
-      expect(console.error).toHaveBeenCalled();
-    });
-    it("Throws an error when using name that is not a string", () => {
-      const dummyValue = [];
-      const badName = 2;
-      wrapper = Enzyme.shallow(
-        <DeviceDetailsConciseRow name={badName} value={dummyValue} />
-      );
-      expect(console.error).toHaveBeenCalled();
-    });
   });
   describe("createTableCellContents()", () => {
     it('should create a StatusIndicator component when passed "status"', () => {

--- a/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsPage.test.jsx
+++ b/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsPage.test.jsx
@@ -22,16 +22,6 @@ describe("DeviceDetailsPage", () => {
     jest.clearAllMocks();
   });
 
-  it("Throws an error", () => {
-    const dummyLocation = {
-      state: {
-        device: "Not a DeviceInfo"
-      }
-    };
-
-    wrapper = Enzyme.shallow(<DeviceDetailsPage location={dummyLocation} />);
-    expect(console.error).toHaveBeenCalled();
-  });
   it("Renders the correct number of child elements", () => {
     const dummyLocation = {
       state: {

--- a/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsTabPanels.test.jsx
+++ b/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsTabPanels.test.jsx
@@ -30,13 +30,5 @@ describe("DeviceDetailsPanels", () => {
       expect(wrapper.find(Container)).toHaveLength(1);
       expect(wrapper.text()).toBe("TEST");
     });
-    it("Throws an error if no props are passed", () => {
-      wrapper = Enzyme.shallow(<DeviceDetailsNotesPanel />);
-      expect(console.error).toHaveBeenCalled();
-    });
-    it("Throws an error if invalid props are passed", () => {
-      wrapper = Enzyme.shallow(<DeviceDetailsNotesPanel extras="" />);
-      expect(console.error).toHaveBeenCalled();
-    });
   });
 });

--- a/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsTabTable.test.jsx
+++ b/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsTabTable.test.jsx
@@ -143,13 +143,4 @@ describe("DeviceDetailsTabTable class", () => {
       );
     });
   });
-  it("Throws an error when using device that is not a DeviceInfo object", () => {
-    const tabs = [""];
-    const device = 454;
-
-    wrapper = Enzyme.shallow(
-      <DeviceDetailsTabTable tabs={tabs} device={device} />
-    );
-    expect(console.error).toHaveBeenCalled();
-  });
 });

--- a/frontend/src/devicelist/DeviceListPage.jsx
+++ b/frontend/src/devicelist/DeviceListPage.jsx
@@ -7,25 +7,24 @@ import ContentsTable from "./ContentsTable";
 import DynamicBreadcrumb from "../general/DynamicBreadcrumb";
 import * as useStyles from "../DefaultMakeStylesTheme";
 
-export default class DeviceListPage extends React.Component {
-  render() {
-    const { dataSource } = this.props;
-    return (
-      <Container>
-        <DynamicBreadcrumb
-          breadcrumbs={[
-            ["Home", "/"],
-            ["My Devices", "Devices"]
-          ]}
-        />
-        <Box className="areaUnderBreadcrumbs">
-          <TitleBox />
-          <ContentsTable classes={useStyles} dataSource={dataSource} />
-        </Box>
-      </Container>
-    );
-  }
+export default function DeviceListPage(props) {
+  const { dataSource } = props;
+  return (
+    <Container>
+      <DynamicBreadcrumb
+        breadcrumbs={[
+          ["Home", "/"],
+          ["My Devices", "Devices"]
+        ]}
+      />
+      <Box className="areaUnderBreadcrumbs">
+        <TitleBox />
+        <ContentsTable classes={useStyles} dataSource={dataSource} />
+      </Box>
+    </Container>
+  );
 }
+
 DeviceListPage.propTypes = {
   dataSource: PropTypes.objectOf(PropTypes.func).isRequired
 };

--- a/frontend/src/devicelist/DevicesTable.jsx
+++ b/frontend/src/devicelist/DevicesTable.jsx
@@ -27,11 +27,13 @@ import DeviceInfo from "../model/DeviceInfo";
 function getComponents() {
   return {
     /*  eslint-disable react/jsx-props-no-spreading */
-    Toolbar: (props) => (
-      <div className="lightestGrey">
-        <MTableToolbar {...props} />
-      </div>
-    )
+    Toolbar: function Components(props) {
+      return (
+        <div className="lightestGrey">
+          <MTableToolbar {...props} />
+        </div>
+      );
+    }
   };
 }
 
@@ -62,7 +64,9 @@ function getColumnInfo() {
     {
       title: "Status",
       field: "status",
-      render: (rowData) => <StatusIndicator status={rowData.status} />,
+      render: function Status(rowData) {
+        return <StatusIndicator status={rowData.status} />;
+      },
       lookup: {
         Online: "Online",
         Pending: "Pending",
@@ -83,7 +87,9 @@ function getColumnInfo() {
       field: "action",
       filtering: false,
       sorting: false,
-      render: (rowData) => <ActionMenu device={rowData} />,
+      render: function Actions(rowData) {
+        return <ActionMenu device={rowData} />;
+      },
       align: "center",
       export: false
     }
@@ -96,7 +102,7 @@ function getDetailPanel() {
       icon: ExpandMore,
       openIcon: ExpandLess,
       tooltip: "Show Device Details",
-      render: (rowData) => {
+      render: function DetailPanel(rowData) {
         return (
           <div className="lightestGrey" style={{ padding: "1.5em" }}>
             <Typography variant="h6">Channels</Typography>
@@ -140,27 +146,25 @@ function getIcons() {
   };
 }
 
-export default class DevicesTable extends React.Component {
-  render() {
-    const { title, devices } = this.props;
-    return (
-      <>
-        <Box>
-          <TableContainer style={{ maxHeight: 570 }}>
-            <MaterialTable
-              title={title}
-              components={getComponents()}
-              columns={getColumnInfo()}
-              data={devices}
-              detailPanel={getDetailPanel()}
-              options={getOptions()}
-              icons={getIcons()}
-            />
-          </TableContainer>
-        </Box>
-      </>
-    );
-  }
+export default function DevicesTable(props) {
+  const { title, devices } = props;
+  return (
+    <>
+      <Box>
+        <TableContainer style={{ maxHeight: 570 }}>
+          <MaterialTable
+            title={title}
+            components={getComponents()}
+            columns={getColumnInfo()}
+            data={devices}
+            detailPanel={getDetailPanel()}
+            options={getOptions()}
+            icons={getIcons()}
+          />
+        </TableContainer>
+      </Box>
+    </>
+  );
 }
 
 DevicesTable.propTypes = {

--- a/frontend/src/devicelist/TabPanel.jsx
+++ b/frontend/src/devicelist/TabPanel.jsx
@@ -3,7 +3,7 @@ import { Box, Typography } from "@material-ui/core";
 import PropTypes from "prop-types";
 
 export default function TabPanel(props) {
-  const { children, value, index, ...other } = props;
+  const { children, value, index } = props;
 
   return (
     <div
@@ -11,7 +11,6 @@ export default function TabPanel(props) {
       hidden={value !== index}
       id={`vertical-tabpanel-${index}`}
       aria-labelledby={`vertical-tab-${index}`}
-      {...other}
     >
       {value === index && (
         <Box p={0}>

--- a/frontend/src/devicelist/TitleBox.jsx
+++ b/frontend/src/devicelist/TitleBox.jsx
@@ -5,25 +5,23 @@ import { NavLink } from "react-router-dom";
 import StreamButton from "../general/Buttons/StreamButton";
 import AddDeviceButton from "../general/Buttons/AddDeviceButton";
 
-export default class TitleBox extends React.Component {
-  render() {
-    return (
-      <>
-        <Box className="flexContents headerAreaNoUnderline">
-          <div className="title">My Devices</div>
-          <div className="alignRightFloat">
-            <NavLink
-              to="/Streaming"
-              activeClassName="hideLinkStyle"
-              className="hideLinkStyle"
-              exact
-            >
-              <StreamButton id="DeviceListStreamBtn" type="submit" />
-            </NavLink>
-            <AddDeviceButton id="DeviceListAddDevBtn" />
-          </div>
-        </Box>
-      </>
-    );
-  }
+export default function TitleBox() {
+  return (
+    <>
+      <Box className="flexContents headerAreaNoUnderline">
+        <div className="title">My Devices</div>
+        <div className="alignRightFloat">
+          <NavLink
+            to="/Streaming"
+            activeClassName="hideLinkStyle"
+            className="hideLinkStyle"
+            exact
+          >
+            <StreamButton id="DeviceListStreamBtn" type="submit" />
+          </NavLink>
+          <AddDeviceButton id="DeviceListAddDevBtn" />
+        </div>
+      </Box>
+    </>
+  );
 }

--- a/frontend/src/devicelist/__tests__/ActionMenu.test.jsx
+++ b/frontend/src/devicelist/__tests__/ActionMenu.test.jsx
@@ -19,7 +19,17 @@ describe("<ActionMenu />", () => {
   let testElement;
 
   beforeEach(() => {
-    const dummyDevice = new DeviceInfo(1, 1, 1, 1, 1, [1, 1], [2, 2]);
+    const dummyDevice = new DeviceInfo(
+      "1:10:111:999",
+      "2020-11-25 20:48:03",
+      "175.214.12.96",
+      "123:456",
+      "Sender 1",
+      "Online",
+      null,
+      "encoder",
+      null
+    );
     wrapper = Enzyme.shallow(<ActionMenu device={dummyDevice} />);
   });
   afterEach(() => {

--- a/frontend/src/devicelist/__tests__/ChannelDetailsTableRow.test.jsx
+++ b/frontend/src/devicelist/__tests__/ChannelDetailsTableRow.test.jsx
@@ -22,7 +22,7 @@ describe("ChannelDetailsTableRow", () => {
     jest.clearAllMocks();
   });
 
-  describe("contains all the correct Components", () => {
+  describe("With InChannel, contains all the correct Components", () => {
     wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={inChannel} />);
     it("Is one (1) TableRow Component", () => {
       expect(wrapper.find(TableRow)).toHaveLength(1);
@@ -40,23 +40,23 @@ describe("ChannelDetailsTableRow", () => {
       expect(wrapper.childAt(2).text()).toBe(`${dummyPort}`);
     });
   });
-  describe("Props validation", () => {
-    /*  eslint-disable no-console */
-    it("works with an InputChannelInfo", () => {
-      wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={inChannel} />);
+
+  describe("With OutChannel, contains all the correct Components ", () => {
+    wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={outChannel} />);
+    it("Is one (1) TableRow Component", () => {
       expect(wrapper.find(TableRow)).toHaveLength(1);
-      expect(wrapper.find(TableCell)).toHaveLength(3);
-      expect(console.error).not.toHaveBeenCalled();
     });
-    it("works with an OutputChannelInfo", () => {
-      wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel={outChannel} />);
-      expect(wrapper.find(TableRow)).toHaveLength(1);
+    it("Has three (3) TableCell Components", () => {
       expect(wrapper.find(TableCell)).toHaveLength(3);
-      expect(console.error).not.toHaveBeenCalled();
     });
-    it("fails if passed an invalid type", () => {
-      wrapper = Enzyme.shallow(<ChannelDetailsTableRow channel="outChannel" />);
-      expect(console.error).toHaveBeenCalled();
+    it("the first TableCell Component contains the channel Id", () => {
+      expect(wrapper.childAt(0).text()).toBe(`${dummyId}`);
+    });
+    it("the second TableCell Component contains the channel name", () => {
+      expect(wrapper.childAt(1).text()).toBe(dummyName);
+    });
+    it("the third TableCell Component contains the channel port", () => {
+      expect(wrapper.childAt(2).text()).toBe(`${dummyPort}`);
     });
   });
 });

--- a/frontend/src/devicelist/__tests__/DevicesTable.test.jsx
+++ b/frontend/src/devicelist/__tests__/DevicesTable.test.jsx
@@ -41,29 +41,4 @@ describe("<DevicesTable/> component", () => {
       expect(wrapper.find(MaterialTable)).toHaveLength(1);
     });
   });
-  describe("Props validation", () => {
-    /*  eslint-disable no-console */
-    const validTitle = "TEST TITLE";
-    const validDevices = [];
-    it("Does not log error if inputs are valid", () => {
-      wrapper = Enzyme.shallow(
-        <DevicesTable title={validTitle} devices={validDevices} />
-      );
-      expect(console.error).not.toHaveBeenCalled();
-    });
-    it("logs an error if title is a string", () => {
-      const notAString = 47384;
-      wrapper = Enzyme.shallow(
-        <DevicesTable title={notAString} devices={validDevices} />
-      );
-      expect(console.error).toHaveBeenCalled();
-    });
-    it("logs an error if devices is not an array of DeviceInfo objects", () => {
-      const notAnArrayOfDeviceInfo = 47384;
-      wrapper = Enzyme.shallow(
-        <DevicesTable title={validTitle} devices={notAnArrayOfDeviceInfo} />
-      );
-      expect(console.error).toHaveBeenCalled();
-    });
-  });
 });

--- a/frontend/src/general/Buttons/StreamButton.jsx
+++ b/frontend/src/general/Buttons/StreamButton.jsx
@@ -4,34 +4,33 @@ import PropTypes from "prop-types";
 
 import { SwapHoriz } from "@material-ui/icons/";
 
-export default class StreamButton extends React.Component {
-  render() {
-    const { id, type } = this.props;
-    const StyledButton = withStyles({
-      root: {
-        background: "linear-gradient(45deg, #59bc31 30%, #59bc31 90%)",
-        borderRadius: 90,
-        border: 0,
-        color: "white",
-        height: 40,
-        padding: "0 5px",
-        margin: "1em"
-      },
-      label: {
-        textTransform: ""
-      }
-    })(Button);
+export default function StreamButton(props) {
+  const { id, type } = props;
+  const StyledButton = withStyles({
+    root: {
+      background: "linear-gradient(45deg, #59bc31 30%, #59bc31 90%)",
+      borderRadius: 90,
+      border: 0,
+      color: "white",
+      height: 40,
+      padding: "0 5px",
+      margin: "1em"
+    },
+    label: {
+      textTransform: ""
+    }
+  })(Button);
 
-    return (
-      <StyledButton id={id} type={type}>
-        <div className="buttonText">
-          <SwapHoriz />
-          Stream
-        </div>
-      </StyledButton>
-    );
-  }
+  return (
+    <StyledButton id={id} type={type}>
+      <div className="buttonText">
+        <SwapHoriz />
+        Stream
+      </div>
+    </StyledButton>
+  );
 }
+
 StreamButton.propTypes = {
   id: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired

--- a/frontend/src/general/DynamicBreadcrumb.jsx
+++ b/frontend/src/general/DynamicBreadcrumb.jsx
@@ -13,7 +13,7 @@ export default function DynamicBreadcrumb(props) {
               color="inherit"
               href={crumb[1]}
               id={`breadcrumb${i}`}
-              key={`breadcrumb${i}`}
+              key={`breadcrumb ${crumb[0]}`}
             >
               <Typography color="textPrimary">{crumb[0]}</Typography>
             </Link>

--- a/frontend/src/general/DynamicBreadcrumb.jsx
+++ b/frontend/src/general/DynamicBreadcrumb.jsx
@@ -2,29 +2,26 @@ import React from "react";
 import { Box, Breadcrumbs, Link, Typography } from "@material-ui/core";
 import PropTypes from "prop-types";
 
-export default class DynamicBreadcrumb extends React.Component {
-  render() {
-    const { breadcrumbs } = this.props;
-    let i = 0;
-    return (
-      <Box padding="2em 0em 0em 1em">
-        <Breadcrumbs aria-label="breadcrumb" id="breadcrumbParent">
-          {breadcrumbs.map((crumb) => {
-            return (
-              <Link
-                color="inherit"
-                href={crumb[1]}
-                id={`breadcrumb${i}`}
-                key={`breadcrumb${i++}`}
-              >
-                <Typography color="textPrimary">{crumb[0]}</Typography>
-              </Link>
-            );
-          })}
-        </Breadcrumbs>
-      </Box>
-    );
-  }
+export default function DynamicBreadcrumb(props) {
+  const { breadcrumbs } = props;
+  return (
+    <Box padding="2em 0em 0em 1em">
+      <Breadcrumbs aria-label="breadcrumb" id="breadcrumbParent">
+        {breadcrumbs.map((crumb, i) => {
+          return (
+            <Link
+              color="inherit"
+              href={crumb[1]}
+              id={`breadcrumb${i}`}
+              key={`breadcrumb${i}`}
+            >
+              <Typography color="textPrimary">{crumb[0]}</Typography>
+            </Link>
+          );
+        })}
+      </Breadcrumbs>
+    </Box>
+  );
 }
 DynamicBreadcrumb.propTypes = {
   breadcrumbs: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired

--- a/frontend/src/general/HomePage.jsx
+++ b/frontend/src/general/HomePage.jsx
@@ -2,18 +2,16 @@ import React from "react";
 import { Container } from "@material-ui/core";
 import DynamicBreadcrumb from "./DynamicBreadcrumb";
 
-export default class HomePage extends React.Component {
-  render() {
-    return (
-      <Container>
-        <DynamicBreadcrumb
-          breadcrumbs={[
-            ["Home", ""],
-            ["My Devices", "Devices"],
-            ["Streaming", "Streaming"]
-          ]}
-        />
-      </Container>
-    );
-  }
+export default function HomePage() {
+  return (
+    <Container>
+      <DynamicBreadcrumb
+        breadcrumbs={[
+          ["Home", ""],
+          ["My Devices", "Devices"],
+          ["Streaming", "Streaming"]
+        ]}
+      />
+    </Container>
+  );
 }

--- a/frontend/src/general/VerticalTabs.jsx
+++ b/frontend/src/general/VerticalTabs.jsx
@@ -13,18 +13,12 @@ export default class VerticalTabs extends React.Component {
     setValue(newTab);
   }
 
-  getTabProps(index) {
-    return {
-      id: `vertical-tab-${index}`,
-      "aria-controls": `vertical-tabpanel-${index}`
-    };
-  }
-
   render() {
     const {
       value,
       classes: { tabs }
     } = this.props;
+
     return (
       <>
         <Tabs
@@ -36,13 +30,22 @@ export default class VerticalTabs extends React.Component {
           indicatorColor="primary"
           variant="scrollable"
         >
-          <Tab label="Senders" {...this.getTabProps(0)} />
-          <Tab label="Receivers" {...this.getTabProps(1)} />
+          <Tab
+            label="Senders"
+            id="vertical-tab-0"
+            aria-controls="vertical-tabpanel-0"
+          />
+          <Tab
+            label="Receivers"
+            id="vertical-tab-1"
+            aria-controls="vertical-tabpanel-1"
+          />
         </Tabs>
       </>
     );
   }
 }
+
 VerticalTabs.propTypes = {
   setValue: PropTypes.func.isRequired,
   value: PropTypes.number.isRequired,

--- a/frontend/src/general/__tests__/DeleteDeviceButton.test.jsx
+++ b/frontend/src/general/__tests__/DeleteDeviceButton.test.jsx
@@ -64,12 +64,9 @@ describe("DeleteButton", () => {
     expect(wrapper.find(Dialog)).toHaveLength(1);
   });
   it("Should open a confirmation dialog when clicked", () => {
-    // check that open is false to begin with
-    expect(setOpen).toBeFalsy;
-
     // click delete button and check that dialog state is open
     wrapper.find("#deleteBtn").simulate("click");
-    expect(setOpen).toBeTruthy;
+    expect(setOpen).toHaveBeenCalledWith(true);
   });
 
   describe("Delete device dialog", () => {
@@ -83,13 +80,13 @@ describe("DeleteButton", () => {
       it("Should close the dialog when clicked", () => {
         // click delete button to set open to true
         wrapper.find("#deleteBtn").simulate("click");
-        expect(setOpen).toBeTruthy;
+        expect(setOpen).toHaveBeenCalledWith(true);
 
         // click cancel
         wrapper.find("#cancelDeleteBtn").simulate("click");
 
         // open should be false now
-        expect(setOpen).toBeFalsy;
+        expect(setOpen).toHaveBeenCalledWith(false);
       });
     });
 
@@ -101,7 +98,7 @@ describe("DeleteButton", () => {
 
           // click the delete button to set open to true
           wrapper.find("#deleteBtn").simulate("click");
-          expect(setOpen).toBeTruthy;
+          expect(setOpen).toHaveBeenCalledWith(true);
 
           // mock axios before clicking confirm
           const axiosPromise = Promise.resolve();
@@ -120,7 +117,7 @@ describe("DeleteButton", () => {
           expect(mockHistoryGo).toHaveBeenCalledWith(0);
 
           // open should be false
-          expect(setOpen).toBeFalsy;
+          expect(setOpen).toHaveBeenCalledWith(false);
         });
       });
 
@@ -131,7 +128,7 @@ describe("DeleteButton", () => {
 
           // click the delete button to set open to true
           wrapper.find("#deleteBtn").simulate("click");
-          expect(setOpen).toBeTruthy;
+          expect(setOpen).toHaveBeenCalledWith(true);
 
           // mock axios before clicking confirm
           const axiosPromise = Promise.resolve();
@@ -150,7 +147,7 @@ describe("DeleteButton", () => {
           expect(mockHistoryPush).toHaveBeenCalledWith("/Devices");
 
           // open should be false
-          expect(setOpen).toBeFalsy;
+          expect(setOpen).toHaveBeenCalledWith(false);
         });
       });
     });

--- a/frontend/src/general/__tests__/HorizontalTabPanel.test.jsx
+++ b/frontend/src/general/__tests__/HorizontalTabPanel.test.jsx
@@ -17,21 +17,6 @@ describe("Horizontal Tab Panel", () => {
   });
 
   describe("Throws an error when", () => {
-    const goodValues = {
-      index: 1,
-      value: 9
-    };
-    it("Not called with props", () => {
-      wrapper = Enzyme.shallow(<HorizontalTabPanel />);
-      expect(console.error).toHaveBeenCalled();
-    });
-    it("called with an index that is not a number", () => {
-      const badIndex = "BadIndex";
-      wrapper = Enzyme.shallow(
-        <HorizontalTabPanel index={badIndex} value={goodValues.value} />
-      );
-      expect(console.error).toHaveBeenCalled();
-    });
     it("Does not render children if the index and value are different", () => {
       wrapper = Enzyme.shallow(
         <HorizontalTabPanel index={1} value={5}>

--- a/frontend/src/model/ConvertDataFormat.js
+++ b/frontend/src/model/ConvertDataFormat.js
@@ -8,26 +8,13 @@ export function convertToDataObject(databaseDevice) {
     databaseDevice.device.privateIpAddress,
     databaseDevice.device.displayName,
     databaseDevice.device.status,
-    databaseDevice.inputs
+    databaseDevice.inputs || databaseDevice.outputs,
+    databaseDevice.inputs ? "receiver" : "sender"
   );
 }
 
 export function convertToServiceObject(deviceInfo) {
-  if (Object.prototype.hasOwnProperty.call(deviceInfo, "outputs")) {
-    return {
-      serialNumber: deviceInfo.serialNumber,
-      lastCommunication: deviceInfo.lastCommunication,
-      device: {
-        serialNumber: deviceInfo.serialNumber,
-        publicIpAddress: deviceInfo.publicIp,
-        privateIpAddress: deviceInfo.privateIp,
-        displayName: deviceInfo.name,
-        status: deviceInfo.status
-      },
-      outputs: deviceInfo.channels
-    };
-  }
-  return {
+  const serviceObject = {
     serialNumber: deviceInfo.serialNumber,
     lastCommunication: deviceInfo.lastCommunication,
     device: {
@@ -36,7 +23,12 @@ export function convertToServiceObject(deviceInfo) {
       privateIpAddress: deviceInfo.privateIp,
       displayName: deviceInfo.name,
       status: deviceInfo.status
-    },
-    inputs: deviceInfo.channels
+    }
   };
+  if (deviceInfo.deviceType === "sender") {
+    serviceObject.outputs = deviceInfo.channels;
+  } else {
+    serviceObject.inputs = deviceInfo.channels;
+  }
+  return serviceObject;
 }

--- a/frontend/src/model/__tests__/ConvertDataFormat.test.js
+++ b/frontend/src/model/__tests__/ConvertDataFormat.test.js
@@ -19,27 +19,27 @@ const sampleOutputChannels = [
 ];
 const sampleLocalSender = new DeviceInfo(
   "test sender serial",
-  null,
+  "2020-11-25 20:48:03",
   "test sender public ip",
   "test sender private ip",
   "test sender display",
   "offline",
-  undefined,
-  undefined
+  sampleOutputChannels,
+  "sender"
 );
 const sampleLocalReceiver = new DeviceInfo(
   "test receiver serial",
-  null,
+  "2020-11-25 20:48:03",
   "test receiver public ip",
   "test receiver private ip",
   "test receiver display",
   "offline",
-  undefined,
-  undefined
+  sampleInputChannels,
+  "receiver"
 );
 const sampleAxiosSender = {
   serialNumber: "test sender serial",
-  lastCommunication: null,
+  lastCommunication: "2020-11-25 20:48:03",
   device: {
     serialNumber: "test sender serial",
     publicIpAddress: "test sender public ip",
@@ -47,12 +47,16 @@ const sampleAxiosSender = {
     displayName: "test sender display",
     status: "offline"
   },
-  outputs: undefined,
+  outputs: [
+    { id: 1, name: "test output ch 1", port: 500, encoder: null },
+    { id: 2, name: "test output ch 2", port: 456, encoder: null },
+    { id: 3, name: "test output ch 3", port: 800, encoder: null }
+  ],
   extras: undefined
 };
 const sampleAxiosReceiver = {
   serialNumber: "test receiver serial",
-  lastCommunication: null,
+  lastCommunication: "2020-11-25 20:48:03",
   device: {
     serialNumber: "test receiver serial",
     publicIpAddress: "test receiver public ip",
@@ -60,7 +64,11 @@ const sampleAxiosReceiver = {
     displayName: "test receiver display",
     status: "offline"
   },
-  inputs: undefined,
+  inputs: [
+    { id: 1, name: "test input ch 1", port: 500, decoder: null },
+    { id: 2, name: "test input ch 2", port: 456, decoder: null },
+    { id: 3, name: "test input ch 3", port: 800, decoder: null }
+  ],
   extras: undefined
 };
 

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -3,4 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
-import 'jest-canvas-mock';
+import "jest-canvas-mock";

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+import 'jest-canvas-mock';

--- a/frontend/src/streamlist/DeleteStream.jsx
+++ b/frontend/src/streamlist/DeleteStream.jsx
@@ -67,5 +67,5 @@ export default function DeleteStream(props) {
 }
 
 DeleteStream.propTypes = {
-  deleteId: PropTypes.objectOf(PropTypes.number).isRequired
+  deleteId: PropTypes.number.isRequired
 };

--- a/frontend/src/streamlist/StreamsTable.jsx
+++ b/frontend/src/streamlist/StreamsTable.jsx
@@ -39,7 +39,9 @@ function getColumnInfo() {
     {
       title: "Status",
       field: "status",
-      render: (rowData) => <StatusIndicator status={rowData.status} />
+      render: function Status(rowData) {
+        return <StatusIndicator status={rowData.status} />;
+      }
     },
     {
       title: "Type",
@@ -54,7 +56,9 @@ function getColumnInfo() {
       field: "action",
       filtering: false,
       sorting: false,
-      render: (rowData) => <DeleteStream deleteId={rowData.id} />,
+      render: function Actions(rowData) {
+        return <DeleteStream deleteId={rowData.id} />;
+      },
       align: "center",
       export: false
     }
@@ -67,7 +71,7 @@ function getDetailPanel() {
       icon: ExpandMore,
       openIcon: ExpandLess,
       tooltip: "Show Stream Details",
-      render: () => {
+      render: function DetailPanel() {
         return (
           <div className="lightestGrey">
             <Typography variant="h6">Additional stream details</Typography>
@@ -101,25 +105,23 @@ function getIcons() {
   };
 }
 
-export default class StreamsTable extends React.Component {
-  render() {
-    const { streams } = this.props;
-    return (
-      <>
-        <Box>
-          <TableContainer>
-            <MaterialTable
-              columns={getColumnInfo()}
-              data={streams}
-              detailPanel={getDetailPanel()}
-              options={getOptions()}
-              icons={getIcons()}
-            />
-          </TableContainer>
-        </Box>
-      </>
-    );
-  }
+export default function StreamsTable(props) {
+  const { streams } = props;
+  return (
+    <>
+      <Box>
+        <TableContainer>
+          <MaterialTable
+            columns={getColumnInfo()}
+            data={streams}
+            detailPanel={getDetailPanel()}
+            options={getOptions()}
+            icons={getIcons()}
+          />
+        </TableContainer>
+      </Box>
+    </>
+  );
 }
 
 StreamsTable.propTypes = {

--- a/frontend/src/streamlist/__tests__/StreamList.test.jsx
+++ b/frontend/src/streamlist/__tests__/StreamList.test.jsx
@@ -3,6 +3,7 @@ import { render, unmountComponentAtNode } from "react-dom";
 import ReactTestUtils, { act } from "react-dom/test-utils";
 import { afterEach, beforeEach, expect, test, jest } from "@jest/globals";
 import axios from "axios";
+import { waitForElementToBeRemoved } from "@testing-library/react";
 import StreamList from "../StreamList";
 import * as SampleData from "../../api/SampleData";
 
@@ -133,7 +134,7 @@ test("Clicking the delete button shows appropriate popup dialog", () => {
   expect(dialogButtons[1].textContent).toBe("Delete");
 });
 
-test("Clicking outside the dialog or 'Cancel' should close the dialog", () => {
+test("Clicking outside the dialog or 'Cancel' should close the dialog", async () => {
   act(() => {
     render(<StreamList dataSource={SampleData} />, container);
   });
@@ -148,9 +149,13 @@ test("Clicking outside the dialog or 'Cancel' should close the dialog", () => {
     ReactTestUtils.Simulate.click(cancelButton);
   });
 
+  await waitForElementToBeRemoved(() =>
+    document.getElementById("delete-stream-dialog")
+  );
+
   // try to get dialog and find it is null
   const dialog = document.getElementById("delete-stream-dialog");
-  expect(dialog).toBeNull;
+  expect(dialog).toBeNull();
 });
 
 test("Clicking 'Confirm' should call axios.delete with the correct stream ID", async () => {
@@ -171,16 +176,17 @@ test("Clicking 'Confirm' should call axios.delete with the correct stream ID", a
   });
 
   // try to get dialog and find it is null
+  await waitForElementToBeRemoved(() =>
+    document.getElementById("delete-stream-dialog")
+  );
   const dialog = document.getElementById("delete-stream-dialog");
-  expect(dialog).toBeNull;
+  expect(dialog).toBeNull();
 
   // expect axios.delete to have been called
   expect(axios.delete).toHaveBeenCalledWith(
     `${process.env.REACT_APP_STREAM}/1`
   );
 
-  const flushPromises = () => new Promise(setImmediate);
-  await flushPromises();
   expect(mockHistoryPush).toHaveBeenCalledWith("/Streaming");
   expect(mockHistoryGo).toHaveBeenCalledWith(0);
 

--- a/frontend/src/streamlist/__tests__/StreamsTable.test.jsx
+++ b/frontend/src/streamlist/__tests__/StreamsTable.test.jsx
@@ -38,19 +38,4 @@ describe("<StreamsTable/> component", () => {
       expect(wrapper.find(MaterialTable)).toHaveLength(1);
     });
   });
-  describe("Props validation", () => {
-    /*  eslint-disable no-console */
-    const validStreams = [];
-    it("Does not log error if inputs are valid", () => {
-      wrapper = Enzyme.shallow(<StreamsTable streamDetails={validStreams} />);
-      expect(console.error).not.toHaveBeenCalled();
-    });
-    it("logs an error if streams is not an array of StreamInfo objects", () => {
-      const notAnArrayOfStreamInfo = 47384;
-      wrapper = Enzyme.shallow(
-        <StreamsTable streams={notAnArrayOfStreamInfo} />
-      );
-      expect(console.error).toHaveBeenCalled();
-    });
-  });
 });


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: #309

**Task description**: 

- Fix frontend code smells. There are now 4 code smells remaining in the frontend.
- Reduce noise in frontend test run output, which currently has a lot of error messages printed even when all tests passed

## Changelog

- Fixed a bunch of issues in tests where we did `expect(...).toBeNull` or `expect(...).toBeFalsy` which does not actually call the assertion. I fixed these to do the proper assertion, and fixed shortcomings in the tests that were revealed by this change.
- Removed a bunch of console references. We had a lot of tests that were testing props validation, which required us to assert that console.error was being called. This was annoying not only for the code smell but for the output that was generated during the test run (there was lots of error logging despite all the tests passing and it made it confusing when looking for test failure issues). In the end i decided to remove these tests, after doing some research and seeing that most people recommend not testing prop validation.
- Removed some unused variables
- Changed components with no state into functional components
- Added display names to unnamed components. This code smell happens when we create a component in an anonymous function and return it. I fixed this issue by naming those functions, which makes the returned component take on the name of the function. The display name is used in error logging in the browser.
- Removed prop spreading, where possible. Prop spreading remains in a couple of places where I couldn't get rid of it.
- Removed usage of unary ++ operator by using the index argument of the map function instead.
- Moved functions that did not reference "this" out of the class / removed them entirely.
- Added `jest-canvas-mock` as a dependency and imported it in `setupTests.js`. This gets rid of a ton of error logs that occur when an HTML canvas is used in Jest. I didn't think we were using an html canvas, but i guess one of the material ui components uses it, since at least 5 of our tests had this massive error log.
- Fixed an uncaught promise in the StreamApi tests, one uncaught promise error remains but that will have to be fixed when we revisit those tests (see below)

## What didn't get fixed
- The code smells in the StreamApi tests are more of a symptom that those tests are not asserting the returned values are correct. I am leaving those smells as a reminder/todo to revisit those tests again sometime, since i didn't have time to fix the tests myself.
- Some of the props spreading issues in index.jsx which arise as a result of using the router and which after a quick google seem to have no solution other than telling eslint to ignore them.
# Testing

**Test coverage**: Should be the same; although some tests were modified or removed, this should not decrease coverage.