### PR TITLE
[#220] Implement an endpoint to create logs

### DIFF
--- a/contracts/api-spec.yaml
+++ b/contracts/api-spec.yaml
@@ -34,6 +34,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LogsModel'
+    post:
+      operationId: createLog
+      description: Create a log
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateLogRequest'
+      responses:
+        '200':
+          description: Successful creation of a log
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogModel'
   /device:
     get:
       operationId: retrieveAllDevices
@@ -411,6 +427,26 @@ components:
         level:
           type: string
           example: 'info'
+        serialNumber:
+          type: string
+          example: '1,2'
+
+    CreateLogRequest:
+      description: A request to create a new log
+      properties:
+        dateTime:
+          type: string
+          pattern: '^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T(0[0-9]|1[0-9]|2[0-4])(\+00:00)$'
+          example: '2021-02-04T08:21:23+00:00'
+        message:
+          type: string
+          example: 'A log message'
+        level:
+          type: string
+          example: 'info'
+        serialNumber:
+          type: string
+          example: '1,2'
 
     DevicesModel:
       description: A list of device serial numbers

--- a/src/main/java/org/beanpod/switchboard/controller/LogController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/LogController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.beanpod.switchboard.dao.LogDaoImpl;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.exceptions.ExceptionType;
+import org.beanpod.switchboard.service.LogService;
 import org.openapitools.api.LogsApi;
 import org.openapitools.model.CreateLogRequest;
 import org.openapitools.model.LogModel;
@@ -21,6 +22,7 @@ public class LogController implements LogsApi {
   public static final String CONTROLLER_NAME = "Log";
   private final LogDaoImpl logDao;
   private final LogMapper logMapper;
+  private final LogService logService;
 
   @Override
   public ResponseEntity<List<LogModel>> retrieveAllLogs() {
@@ -35,10 +37,9 @@ public class LogController implements LogsApi {
   @Override
   public ResponseEntity<LogModel> createLog(@Valid CreateLogRequest createLogRequest) {
     return Optional.of(createLogRequest)
-        .map(logMapper::toLogDto)
-        .map(logDao::createLog)
-        .map(logMapper::toLogEntity)
-        .map(logMapper::toLogModel)
+        .map(logMapper::createLogRequestToLogModel)
+        .map(logService::createLog)
+        .map(logMapper::logDtoToLogModel)
         .map(ResponseEntity::ok)
         .orElseThrow(() -> new ExceptionType.UnknownException(CONTROLLER_NAME));
   }

--- a/src/main/java/org/beanpod/switchboard/controller/LogController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/LogController.java
@@ -4,9 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
 import org.beanpod.switchboard.dao.LogDaoImpl;
-import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.exceptions.ExceptionType;
 import org.openapitools.api.LogsApi;
@@ -19,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class LogController implements LogsApi {
+
   public static final String CONTROLLER_NAME = "Log";
   private final LogDaoImpl logDao;
   private final LogMapper logMapper;
@@ -34,7 +33,7 @@ public class LogController implements LogsApi {
   }
 
   @Override
-  public ResponseEntity<LogModel> createLog(@Valid CreateLogRequest createLogRequest){
+  public ResponseEntity<LogModel> createLog(@Valid CreateLogRequest createLogRequest) {
     return Optional.of(createLogRequest)
         .map(logMapper::toLogDto)
         .map(logDao::createLog)

--- a/src/main/java/org/beanpod/switchboard/controller/LogController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/LogController.java
@@ -1,9 +1,16 @@
 package org.beanpod.switchboard.controller;
 
 import java.util.List;
+import java.util.Optional;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import org.beanpod.switchboard.dao.LogDaoImpl;
+import org.beanpod.switchboard.dto.LogDto;
+import org.beanpod.switchboard.dto.mapper.LogMapper;
+import org.beanpod.switchboard.exceptions.ExceptionType;
 import org.openapitools.api.LogsApi;
+import org.openapitools.model.CreateLogRequest;
 import org.openapitools.model.LogModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,8 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class LogController implements LogsApi {
-
+  public static final String CONTROLLER_NAME = "Log";
   private final LogDaoImpl logDao;
+  private final LogMapper logMapper;
 
   @Override
   public ResponseEntity<List<LogModel>> retrieveAllLogs() {
@@ -23,5 +31,16 @@ public class LogController implements LogsApi {
   @Override
   public ResponseEntity<List<LogModel>> retrieveDeviceLogs(@PathVariable String serialNumber) {
     return ResponseEntity.ok(logDao.getDeviceLogs(serialNumber));
+  }
+
+  @Override
+  public ResponseEntity<LogModel> createLog(@Valid CreateLogRequest createLogRequest){
+    return Optional.of(createLogRequest)
+        .map(logMapper::toLogDto)
+        .map(logDao::createLog)
+        .map(logMapper::toLogEntity)
+        .map(logMapper::toLogModel)
+        .map(ResponseEntity::ok)
+        .orElseThrow(() -> new ExceptionType.UnknownException(CONTROLLER_NAME));
   }
 }

--- a/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
+++ b/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
@@ -1,9 +1,14 @@
 package org.beanpod.switchboard.dao;
 
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.beanpod.switchboard.dto.EncoderDto;
+import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.repository.LogRepository;
+import org.openapitools.model.CreateLogRequest;
 import org.openapitools.model.LogModel;
 import org.springframework.stereotype.Component;
 
@@ -20,5 +25,9 @@ public class LogDaoImpl {
 
   public List<LogModel> getDeviceLogs(String serialNumber) {
     return logMapper.toLogModels(logRepository.findBySerialNumber(serialNumber));
+  }
+
+  public LogDto createLog(LogDto logDto){
+    return logMapper.toLogDto1(logRepository.save(logMapper.toLogEntity(logDto)));
   }
 }

--- a/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
+++ b/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
@@ -24,6 +24,6 @@ public class LogDaoImpl {
   }
 
   public LogDto createLog(LogDto logDto) {
-    return logMapper.toLogDto1(logRepository.save(logMapper.toLogEntity(logDto)));
+    return logMapper.logEntitytoLogDto(logRepository.save(logMapper.toLogEntity(logDto)));
   }
 }

--- a/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
+++ b/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
@@ -24,6 +24,6 @@ public class LogDaoImpl {
   }
 
   public LogDto createLog(LogDto logDto) {
-    return logMapper.logEntitytoLogDto(logRepository.save(logMapper.toLogEntity(logDto)));
+    return logMapper.logEntityToLogDto(logRepository.save(logMapper.toLogEntity(logDto)));
   }
 }

--- a/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
+++ b/src/main/java/org/beanpod/switchboard/dao/LogDaoImpl.java
@@ -1,14 +1,10 @@
 package org.beanpod.switchboard.dao;
 
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.beanpod.switchboard.dto.EncoderDto;
 import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.repository.LogRepository;
-import org.openapitools.model.CreateLogRequest;
 import org.openapitools.model.LogModel;
 import org.springframework.stereotype.Component;
 
@@ -27,7 +23,7 @@ public class LogDaoImpl {
     return logMapper.toLogModels(logRepository.findBySerialNumber(serialNumber));
   }
 
-  public LogDto createLog(LogDto logDto){
+  public LogDto createLog(LogDto logDto) {
     return logMapper.toLogDto1(logRepository.save(logMapper.toLogEntity(logDto)));
   }
 }

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/LogMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/LogMapper.java
@@ -1,8 +1,13 @@
 package org.beanpod.switchboard.dto.mapper;
 
+import java.time.OffsetDateTime;
+import java.util.IllegalFormatException;
 import java.util.List;
+import java.util.regex.Pattern;
+import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.mapstruct.Mapper;
+import org.openapitools.model.CreateLogRequest;
 import org.openapitools.model.LogModel;
 
 @Mapper(componentModel = "spring")
@@ -11,4 +16,17 @@ public interface LogMapper {
   List<LogModel> toLogModels(List<LogEntity> logEntityList);
 
   LogModel toLogModel(LogEntity logEntity);
+
+  LogEntity toLogEntity(LogDto logDto);
+
+  LogDto toLogDto(CreateLogRequest createLogRequest);
+
+  LogDto toLogDto1(LogEntity logEntity);
+
+  /* to convert string to OffsetDateTime
+   * value must be of YYYY-MM-DDTHH:mm:ss+00:00
+   */
+  default OffsetDateTime map(String value){
+    return OffsetDateTime.parse(value);
+  }
 }

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/LogMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/LogMapper.java
@@ -1,9 +1,7 @@
 package org.beanpod.switchboard.dto.mapper;
 
 import java.time.OffsetDateTime;
-import java.util.IllegalFormatException;
 import java.util.List;
-import java.util.regex.Pattern;
 import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.mapstruct.Mapper;
@@ -26,7 +24,7 @@ public interface LogMapper {
   /* to convert string to OffsetDateTime
    * value must be of YYYY-MM-DDTHH:mm:ss+00:00
    */
-  default OffsetDateTime map(String value){
+  default OffsetDateTime map(String value) {
     return OffsetDateTime.parse(value);
   }
 }

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/LogMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/LogMapper.java
@@ -19,7 +19,7 @@ public interface LogMapper {
 
   LogDto toLogDto(CreateLogRequest createLogRequest);
 
-  LogDto toLogDto1(LogEntity logEntity);
+  LogDto logEntitytoLogDto(LogEntity logEntity);
 
   /* to convert string to OffsetDateTime
    * value must be of YYYY-MM-DDTHH:mm:ss+00:00

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/LogMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/LogMapper.java
@@ -17,9 +17,13 @@ public interface LogMapper {
 
   LogEntity toLogEntity(LogDto logDto);
 
-  LogDto toLogDto(CreateLogRequest createLogRequest);
+  LogModel logDtoToLogModel(LogDto logDto);
 
-  LogDto logEntitytoLogDto(LogEntity logEntity);
+  LogDto logModelToLogDto(LogModel logModel);
+
+  LogModel createLogRequestToLogModel(CreateLogRequest createLogRequest);
+
+  LogDto logEntityToLogDto(LogEntity logEntity);
 
   /* to convert string to OffsetDateTime
    * value must be of YYYY-MM-DDTHH:mm:ss+00:00

--- a/src/main/java/org/beanpod/switchboard/service/LogService.java
+++ b/src/main/java/org/beanpod/switchboard/service/LogService.java
@@ -2,9 +2,13 @@ package org.beanpod.switchboard.service;
 
 import java.time.OffsetDateTime;
 import lombok.RequiredArgsConstructor;
+import org.beanpod.switchboard.dao.LogDaoImpl;
+import org.beanpod.switchboard.dto.LogDto;
+import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.beanpod.switchboard.repository.LogRepository;
 import org.beanpod.switchboard.util.DateUtil;
+import org.openapitools.model.LogModel;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,6 +17,8 @@ public class LogService {
 
   private final DateUtil dateUtil;
   private final LogRepository logRepository;
+  private final LogDaoImpl logDao;
+  private final LogMapper logMapper;
 
   public void createLog(String message, String level, String serialNumber) {
 
@@ -24,5 +30,9 @@ public class LogService {
             .serialNumber(serialNumber)
             .build();
     logRepository.save(logEntity);
+  }
+
+  public LogDto createLog(LogModel logModel) {
+    return logDao.createLog(logMapper.logModelToLogDto(logModel));
   }
 }

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -26,12 +26,9 @@ class LogControllerTest {
   private static LogModel logModel;
   private static LogDto logDto;
   private static LogEntity logEntity;
-  @InjectMocks
-  private LogController logController;
-  @Mock
-  private LogDaoImpl logDao;
-  @Mock
-  private LogMapper logMapper;
+  @InjectMocks private LogController logController;
+  @Mock private LogDaoImpl logDao;
+  @Mock private LogMapper logMapper;
 
   @BeforeEach
   void setupLogFixture() {
@@ -39,7 +36,6 @@ class LogControllerTest {
     logModel = LogFixture.getLogModel();
     logDto = LogFixture.getLogDto();
     logEntity = LogFixture.getLogEntity();
-
   }
 
   @BeforeEach
@@ -70,8 +66,8 @@ class LogControllerTest {
     when(logMapper.toLogModel(any())).thenReturn(logModel);
     when(logMapper.toLogEntity(any())).thenReturn(logEntity);
 
-    ResponseEntity<LogModel> responseEntity = logController
-        .createLog(LogFixture.getCreateLogRequest());
+    ResponseEntity<LogModel> responseEntity =
+        logController.createLog(LogFixture.getCreateLogRequest());
 
     assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
     assertEquals(logModel, responseEntity.getBody());

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -2,16 +2,21 @@ package org.beanpod.switchboard.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.beanpod.switchboard.dao.LogDaoImpl;
+import org.beanpod.switchboard.dto.LogDto;
+import org.beanpod.switchboard.dto.mapper.LogMapper;
+import org.beanpod.switchboard.entity.LogEntity;
 import org.beanpod.switchboard.fixture.LogFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.openapitools.model.CreateLogRequest;
 import org.openapitools.model.LogModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,12 +24,20 @@ import org.springframework.http.ResponseEntity;
 class LogControllerTest {
 
   private static List<LogModel> logModels;
+  private static LogModel logModel;
+  private static LogDto logDto;
+  private static LogEntity logEntity;
   @InjectMocks private LogController logController;
   @Mock private LogDaoImpl logDao;
+  @Mock private LogMapper logMapper;
 
   @BeforeEach
   void setupLogFixture() {
     logModels = LogFixture.getListOfLogs();
+    logModel = LogFixture.getLogModel();
+    logDto = LogFixture.getLogDto();
+    logEntity = LogFixture.getLogEntity();
+
   }
 
   @BeforeEach
@@ -46,5 +59,19 @@ class LogControllerTest {
     ResponseEntity<List<LogModel>> response = logController.retrieveDeviceLogs("1");
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertIterableEquals(logModels, response.getBody());
+  }
+
+  @Test
+  final void testCreateLog(){
+    when(logDao.createLog(logDto)).thenReturn(logDto);
+    when(logMapper.toLogDto(any())).thenReturn(logDto);
+    when(logMapper.toLogModel(any())).thenReturn(logModel);
+    when(logMapper.toLogEntity(any())).thenReturn(logEntity);
+
+    ResponseEntity<LogModel> responseEntity = logController.createLog(LogFixture.getCreateLogRequest());
+    System.out.println(responseEntity.getBody());
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertEquals(logModel,responseEntity.getBody());
   }
 }

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -11,6 +11,7 @@ import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.beanpod.switchboard.fixture.LogFixture;
+import org.beanpod.switchboard.service.LogService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -29,6 +30,7 @@ class LogControllerTest {
   @InjectMocks private LogController logController;
   @Mock private LogDaoImpl logDao;
   @Mock private LogMapper logMapper;
+  @Mock private LogService logService;
 
   @BeforeEach
   void setupLogFixture() {
@@ -61,10 +63,9 @@ class LogControllerTest {
 
   @Test
   final void testCreateLog() {
-    when(logDao.createLog(logDto)).thenReturn(logDto);
-    when(logMapper.toLogDto(any())).thenReturn(logDto);
-    when(logMapper.toLogModel(any())).thenReturn(logModel);
-    when(logMapper.toLogEntity(any())).thenReturn(logEntity);
+    when(logService.createLog(any())).thenReturn(logDto);
+    when(logMapper.createLogRequestToLogModel(any())).thenReturn(logModel);
+    when(logMapper.logDtoToLogModel(any())).thenReturn(logModel);
 
     ResponseEntity<LogModel> responseEntity =
         logController.createLog(LogFixture.getCreateLogRequest());

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -72,7 +72,6 @@ class LogControllerTest {
 
     ResponseEntity<LogModel> responseEntity = logController
         .createLog(LogFixture.getCreateLogRequest());
-    System.out.println(responseEntity.getBody());
 
     assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
     assertEquals(logModel, responseEntity.getBody());

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.openapitools.model.CreateLogRequest;
 import org.openapitools.model.LogModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,9 +26,12 @@ class LogControllerTest {
   private static LogModel logModel;
   private static LogDto logDto;
   private static LogEntity logEntity;
-  @InjectMocks private LogController logController;
-  @Mock private LogDaoImpl logDao;
-  @Mock private LogMapper logMapper;
+  @InjectMocks
+  private LogController logController;
+  @Mock
+  private LogDaoImpl logDao;
+  @Mock
+  private LogMapper logMapper;
 
   @BeforeEach
   void setupLogFixture() {
@@ -62,16 +64,17 @@ class LogControllerTest {
   }
 
   @Test
-  final void testCreateLog(){
+  final void testCreateLog() {
     when(logDao.createLog(logDto)).thenReturn(logDto);
     when(logMapper.toLogDto(any())).thenReturn(logDto);
     when(logMapper.toLogModel(any())).thenReturn(logModel);
     when(logMapper.toLogEntity(any())).thenReturn(logEntity);
 
-    ResponseEntity<LogModel> responseEntity = logController.createLog(LogFixture.getCreateLogRequest());
+    ResponseEntity<LogModel> responseEntity = logController
+        .createLog(LogFixture.getCreateLogRequest());
     System.out.println(responseEntity.getBody());
 
     assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-    assertEquals(logModel,responseEntity.getBody());
+    assertEquals(logModel, responseEntity.getBody());
   }
 }

--- a/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
+++ b/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
@@ -61,7 +61,7 @@ class LogDaoImplTest {
 
   @Test
   final void testCreateLog() {
-    when(logMapper.logEntitytoLogDto(logEntity)).thenReturn(logDto);
+    when(logMapper.logEntityToLogDto(logEntity)).thenReturn(logDto);
     when(logMapper.toLogEntity(logDto)).thenReturn(logEntity);
     when(logRepository.save(logEntity)).thenReturn(logEntity);
 

--- a/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
+++ b/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
@@ -1,10 +1,12 @@
 package org.beanpod.switchboard.dao;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.beanpod.switchboard.fixture.DeviceFixture;
@@ -20,6 +22,8 @@ import org.openapitools.model.LogModel;
 class LogDaoImplTest {
   public static List<LogModel> logModels;
   public static List<LogEntity> logEntities;
+  public static LogDto logDto;
+  public static LogEntity logEntity;
 
   @InjectMocks LogDaoImpl logDao;
   @Mock LogRepository logRepository;
@@ -29,6 +33,8 @@ class LogDaoImplTest {
   void setupLogFixture() {
     logModels = LogFixture.getListOfLogs();
     logEntities = LogFixture.getListOfLogEntity();
+    logDto = LogFixture.getLogDto();
+    logEntity = LogFixture.getLogEntity();
   }
 
   @BeforeEach
@@ -50,5 +56,16 @@ class LogDaoImplTest {
     when(logMapper.toLogModels(any())).thenReturn(logModels);
     List<LogModel> logs = logDao.getDeviceLogs(DeviceFixture.SERIAL_NUMBER);
     assertIterableEquals(logModels, logs);
+  }
+
+  @Test
+  final void testCreateLog(){
+    when(logMapper.toLogDto1(logEntity)).thenReturn(logDto);
+    when(logMapper.toLogEntity(logDto)).thenReturn(logEntity);
+    when(logRepository.save(logEntity)).thenReturn(logEntity);
+
+    LogDto responseLogDto = logDao.createLog(logDto);
+
+    assertEquals(logDto, responseLogDto);
   }
 }

--- a/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
+++ b/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
@@ -61,7 +61,7 @@ class LogDaoImplTest {
 
   @Test
   final void testCreateLog() {
-    when(logMapper.toLogDto1(logEntity)).thenReturn(logDto);
+    when(logMapper.logEntitytoLogDto(logEntity)).thenReturn(logDto);
     when(logMapper.toLogEntity(logDto)).thenReturn(logEntity);
     when(logRepository.save(logEntity)).thenReturn(logEntity);
 

--- a/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
+++ b/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
@@ -20,14 +20,18 @@ import org.mockito.MockitoAnnotations;
 import org.openapitools.model.LogModel;
 
 class LogDaoImplTest {
+
   public static List<LogModel> logModels;
   public static List<LogEntity> logEntities;
   public static LogDto logDto;
   public static LogEntity logEntity;
 
-  @InjectMocks LogDaoImpl logDao;
-  @Mock LogRepository logRepository;
-  @Mock LogMapper logMapper;
+  @InjectMocks
+  LogDaoImpl logDao;
+  @Mock
+  LogRepository logRepository;
+  @Mock
+  LogMapper logMapper;
 
   @BeforeEach
   void setupLogFixture() {
@@ -59,7 +63,7 @@ class LogDaoImplTest {
   }
 
   @Test
-  final void testCreateLog(){
+  final void testCreateLog() {
     when(logMapper.toLogDto1(logEntity)).thenReturn(logDto);
     when(logMapper.toLogEntity(logDto)).thenReturn(logEntity);
     when(logRepository.save(logEntity)).thenReturn(logEntity);

--- a/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
+++ b/src/test/java/org/beanpod/switchboard/dao/LogDaoImplTest.java
@@ -26,12 +26,9 @@ class LogDaoImplTest {
   public static LogDto logDto;
   public static LogEntity logEntity;
 
-  @InjectMocks
-  LogDaoImpl logDao;
-  @Mock
-  LogRepository logRepository;
-  @Mock
-  LogMapper logMapper;
+  @InjectMocks LogDaoImpl logDao;
+  @Mock LogRepository logRepository;
+  @Mock LogMapper logMapper;
 
   @BeforeEach
   void setupLogFixture() {

--- a/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
+++ b/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
@@ -19,7 +19,11 @@ public class LogFixture {
   public static final String level = "info";
 
   public static LogModel getLogModel() {
-    return new LogModel().id(id).dateTime(dateTime).message(message).level(level)
+    return new LogModel()
+        .id(id)
+        .dateTime(dateTime)
+        .message(message)
+        .level(level)
         .serialNumber(DeviceFixture.SERIAL_NUMBER);
   }
 

--- a/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
+++ b/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
@@ -7,18 +7,19 @@ import java.util.ArrayList;
 import java.util.List;
 import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.entity.LogEntity;
+import org.openapitools.model.CreateLogRequest;
 import org.openapitools.model.LogModel;
 
 public class LogFixture {
 
   public static final Long id = (long) 1;
   public static final OffsetDateTime dateTime =
-      OffsetDateTime.of(LocalDateTime.of(2017, 05, 12, 05, 45), ZoneOffset.ofHoursMinutes(6, 30));
+      OffsetDateTime.of(LocalDateTime.of(2017, 05, 12, 05, 45), ZoneOffset.ofHoursMinutes(0, 0));
   public static final String message = "data inserted";
   public static final String level = "info";
 
   public static LogModel getLogModel() {
-    return new LogModel().id(id).dateTime(dateTime).message(message).level(level);
+    return new LogModel().id(id).dateTime(dateTime).message(message).level(level).serialNumber(DeviceFixture.SERIAL_NUMBER);
   }
 
   public static LogEntity getLogEntity() {
@@ -39,6 +40,14 @@ public class LogFixture {
         .level(level)
         .serialNumber(DeviceFixture.SERIAL_NUMBER)
         .build();
+  }
+
+  public static CreateLogRequest getCreateLogRequest(){
+    return new CreateLogRequest()
+        .serialNumber(DeviceFixture.SERIAL_NUMBER)
+        .level(level)
+        .message(message)
+        .dateTime("2017-05-12T05:45:00+00:00");
   }
 
   public static List<LogModel> getListOfLogs() {

--- a/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
+++ b/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
@@ -19,7 +19,8 @@ public class LogFixture {
   public static final String level = "info";
 
   public static LogModel getLogModel() {
-    return new LogModel().id(id).dateTime(dateTime).message(message).level(level).serialNumber(DeviceFixture.SERIAL_NUMBER);
+    return new LogModel().id(id).dateTime(dateTime).message(message).level(level)
+        .serialNumber(DeviceFixture.SERIAL_NUMBER);
   }
 
   public static LogEntity getLogEntity() {
@@ -32,7 +33,7 @@ public class LogFixture {
         .build();
   }
 
-  public static LogDto getLogDto(){
+  public static LogDto getLogDto() {
     return LogDto.builder()
         .id(id)
         .dateTime(dateTime)
@@ -42,7 +43,7 @@ public class LogFixture {
         .build();
   }
 
-  public static CreateLogRequest getCreateLogRequest(){
+  public static CreateLogRequest getCreateLogRequest() {
     return new CreateLogRequest()
         .serialNumber(DeviceFixture.SERIAL_NUMBER)
         .level(level)

--- a/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
+++ b/src/test/java/org/beanpod/switchboard/fixture/LogFixture.java
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.openapitools.model.LogModel;
 
@@ -22,6 +23,16 @@ public class LogFixture {
 
   public static LogEntity getLogEntity() {
     return LogEntity.builder()
+        .id(id)
+        .dateTime(dateTime)
+        .message(message)
+        .level(level)
+        .serialNumber(DeviceFixture.SERIAL_NUMBER)
+        .build();
+  }
+
+  public static LogDto getLogDto(){
+    return LogDto.builder()
         .id(id)
         .dateTime(dateTime)
         .message(message)

--- a/src/test/java/org/beanpod/switchboard/mapper/LogMapperTest.java
+++ b/src/test/java/org/beanpod/switchboard/mapper/LogMapperTest.java
@@ -39,7 +39,8 @@ public class LogMapperTest {
       OffsetDateTime offsetDateTime = logMapper.map(validDateTime);
       Assertions.fail("Expected exception to be thrown");
     } catch (DateTimeParseException e) {
-      assertThat(e).isInstanceOf(DateTimeParseException.class)
+      assertThat(e)
+          .isInstanceOf(DateTimeParseException.class)
           .hasMessage("Text '2017-05-12 05:45+00:00' could not be parsed at index 10");
     }
   }

--- a/src/test/java/org/beanpod/switchboard/mapper/LogMapperTest.java
+++ b/src/test/java/org/beanpod/switchboard/mapper/LogMapperTest.java
@@ -1,0 +1,44 @@
+package org.beanpod.switchboard.mapper;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.spy;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import org.beanpod.switchboard.dto.mapper.LogMapper;
+import org.beanpod.switchboard.fixture.LogFixture;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LogMapperTest {
+  private static LogMapper logMapper;
+  private static OffsetDateTime dateTime;
+
+  @BeforeEach
+  void setup(){
+    logMapper = spy(LogMapper.class);
+    dateTime = LogFixture.dateTime;
+  }
+
+  @Test
+  void mapTestValidDateString(){
+    String validDateTime  = "2017-05-12T05:45+00:00";
+    OffsetDateTime offsetDateTime = logMapper.map(validDateTime);
+
+    assertEquals(dateTime, offsetDateTime);
+  }
+
+  @Test
+  void mapTestInvalidDateString(){
+    String validDateTime  = "2017-05-12 05:45+00:00";
+
+    try {
+      OffsetDateTime offsetDateTime = logMapper.map(validDateTime);
+      Assertions.fail("Expected exception to be thrown");
+    }catch(DateTimeParseException e){
+      assertThat(e).isInstanceOf(DateTimeParseException.class).hasMessage("Text '2017-05-12 05:45+00:00' could not be parsed at index 10");
+    }
+  }
+}

--- a/src/test/java/org/beanpod/switchboard/mapper/LogMapperTest.java
+++ b/src/test/java/org/beanpod/switchboard/mapper/LogMapperTest.java
@@ -13,32 +13,34 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class LogMapperTest {
+
   private static LogMapper logMapper;
   private static OffsetDateTime dateTime;
 
   @BeforeEach
-  void setup(){
+  void setup() {
     logMapper = spy(LogMapper.class);
     dateTime = LogFixture.dateTime;
   }
 
   @Test
-  void mapTestValidDateString(){
-    String validDateTime  = "2017-05-12T05:45+00:00";
+  void mapTestValidDateString() {
+    String validDateTime = "2017-05-12T05:45+00:00";
     OffsetDateTime offsetDateTime = logMapper.map(validDateTime);
 
     assertEquals(dateTime, offsetDateTime);
   }
 
   @Test
-  void mapTestInvalidDateString(){
-    String validDateTime  = "2017-05-12 05:45+00:00";
+  void mapTestInvalidDateString() {
+    String validDateTime = "2017-05-12 05:45+00:00";
 
     try {
       OffsetDateTime offsetDateTime = logMapper.map(validDateTime);
       Assertions.fail("Expected exception to be thrown");
-    }catch(DateTimeParseException e){
-      assertThat(e).isInstanceOf(DateTimeParseException.class).hasMessage("Text '2017-05-12 05:45+00:00' could not be parsed at index 10");
+    } catch (DateTimeParseException e) {
+      assertThat(e).isInstanceOf(DateTimeParseException.class)
+          .hasMessage("Text '2017-05-12 05:45+00:00' could not be parsed at index 10");
     }
   }
 }

--- a/src/test/java/org/beanpod/switchboard/service/LogServiceTest.java
+++ b/src/test/java/org/beanpod/switchboard/service/LogServiceTest.java
@@ -51,7 +51,7 @@ class LogServiceTest {
   }
 
   @Test
-  final void testCreateLog(){
+  final void testCreateLog() {
     when(logRepository.save(any())).thenReturn(logEntity);
     when(logMapper.logModelToLogDto(any())).thenReturn(logDto);
     when(logService.createLog(logModel)).thenReturn(logDto);

--- a/src/test/java/org/beanpod/switchboard/service/LogServiceTest.java
+++ b/src/test/java/org/beanpod/switchboard/service/LogServiceTest.java
@@ -1,10 +1,13 @@
 package org.beanpod.switchboard.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.beanpod.switchboard.dao.LogDaoImpl;
+import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.entity.LogEntity;
 import org.beanpod.switchboard.fixture.DeviceFixture;
@@ -15,18 +18,24 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.openapitools.model.LogModel;
 
 class LogServiceTest {
 
   public static LogEntity logEntity;
+  public static LogDto logDto;
+  public static LogModel logModel;
 
   @InjectMocks LogService logService;
   @Mock LogRepository logRepository;
   @Mock LogMapper logMapper;
+  @Mock LogDaoImpl logDao;
 
   @BeforeEach
   void setupLogFixture() {
     logEntity = LogFixture.getLogEntity();
+    logDto = LogFixture.getLogDto();
+    logModel = LogFixture.getLogModel();
   }
 
   @BeforeEach
@@ -39,5 +48,16 @@ class LogServiceTest {
     when(logRepository.save(any())).thenReturn(logEntity);
     logService.createLog("im a log", "info", DeviceFixture.SERIAL_NUMBER);
     verify(logRepository, times(1)).save(any());
+  }
+
+  @Test
+  final void testCreateLog(){
+    when(logRepository.save(any())).thenReturn(logEntity);
+    when(logMapper.logModelToLogDto(any())).thenReturn(logDto);
+    when(logService.createLog(logModel)).thenReturn(logDto);
+
+    LogDto actualLodModel = logService.createLog(logModel);
+
+    assertEquals(logDto, actualLodModel);
   }
 }


### PR DESCRIPTION
**Issue number**: #220 

**Task description**: 

 - Update the contracts to have a CreateLogRequest class and a post endpoint for creating a log (/logs)
 - Override the controller method createLog within the LogController class
 - Add additional mappers, one of them is a mapper to map a String to OffsetDateTime
 - Add createLog method in the LogDaoImpl class
 - Add two tests for the service and controller
- Add two tests for default method map in LogMapper

# Additional notes

**Note to reviewers**:
- dateTime attribute in the CreateLogRequest accepts the following format: YYYY-MM-DDTHH:mm:ss+00:00. For example, "2021-02-04T08:21:23+00:00" is an accepted value.
- Here's a screenshot for the request to ease your revision process:
![postman request for creating a new log](https://user-images.githubusercontent.com/39838955/108624826-483ca000-7415-11eb-8375-9461a2579fc4.png)
