### PR TITLE
[#346] Refactor Homepage to use Page

### DIFF
--- a/frontend/src/homepage/HomePage.jsx
+++ b/frontend/src/homepage/HomePage.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import Page from "../general/Page";
+import HomePageContents from "./HomePageContents";
+
+export default function HomePage() {
+  return (
+    <Page title="Dashboard" breadcrumbs={[["Home", ""]]}>
+      <HomePageContents />
+    </Page>
+  );
+}

--- a/frontend/src/homepage/HomePageContents.jsx
+++ b/frontend/src/homepage/HomePageContents.jsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { Box, Container, Grid } from "@material-ui/core";
-import DynamicBreadcrumb from "../general/DynamicBreadcrumb";
+import { Grid } from "@material-ui/core";
 
 import GridColumn from "../general/dashboard/GridColumn";
 import ActiveStreamCard from "./ActiveStreamCard";
@@ -10,29 +9,29 @@ import AdminPanelCard from "./AdminPanelCard";
 
 export default function HomePageContents() {
   return (
-      <Grid
-        container
-        justify="center"
-        alignItems="stretch"
-        direction="row"
-        spacing={3}
-      >
-        <Grid item xs={6}>
-          <Grid style={{ height: "100%" }}>
-            <ActiveStreamCard />
-          </Grid>
+    <Grid
+      container
+      justify="center"
+      alignItems="stretch"
+      direction="row"
+      spacing={3}
+    >
+      <Grid item xs={6}>
+        <Grid style={{ height: "100%" }}>
+          <ActiveStreamCard />
         </Grid>
-        <GridColumn width={6}>
-          <Grid item xs={12}>
-            <DevicesCard />
-          </Grid>
-          <Grid item xs={12}>
-            <ActivityLogCard />
-          </Grid>
-          <Grid item xs={12}>
-            <AdminPanelCard />
-          </Grid>
-        </GridColumn>
       </Grid>
+      <GridColumn width={6}>
+        <Grid item xs={12}>
+          <DevicesCard />
+        </Grid>
+        <Grid item xs={12}>
+          <ActivityLogCard />
+        </Grid>
+        <Grid item xs={12}>
+          <AdminPanelCard />
+        </Grid>
+      </GridColumn>
+    </Grid>
   );
 }

--- a/frontend/src/homepage/HomePageContents.jsx
+++ b/frontend/src/homepage/HomePageContents.jsx
@@ -8,13 +8,8 @@ import ActivityLogCard from "./ActivityLogCard";
 import DevicesCard from "./DevicesCard";
 import AdminPanelCard from "./AdminPanelCard";
 
-export default function HomePage() {
+export default function HomePageContents() {
   return (
-    <Container>
-      <DynamicBreadcrumb breadcrumbs={[["Home", ""]]} />
-      <Box className="flexContents headerAreaUnderline">
-        <div className="title">Dashboard</div>
-      </Box>
       <Grid
         container
         justify="center"
@@ -39,6 +34,5 @@ export default function HomePage() {
           </Grid>
         </GridColumn>
       </Grid>
-    </Container>
   );
 }

--- a/frontend/src/homepage/__tests__/HomePage.test.jsx
+++ b/frontend/src/homepage/__tests__/HomePage.test.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import HomePage from "../HomePage";
+import HomePageContents from "../HomePageContents";
+import Page from "../../general/Page";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+
+describe("<HomePage/> functional component", ()=>{
+    let wrapper;
+    const expectedTitle = "Dashboard";
+    const expectedCrumb = [["Home", ""]];
+    describe("returns a component that", ()=>{
+        beforeEach(()=>{
+            wrapper = Enzyme.shallow(<HomePage/>);
+        })
+        it("contains 1 <Page/> component with the correct props", ()=>{
+            expect(wrapper.find(Page)).toHaveLength(1);
+            
+            const page= wrapper.find(Page).first();
+            expect(page.props().title).toBe(expectedTitle);
+            expect(page.props().breadcrumbs).toBeInstanceOf(Array);
+            expect(page.props().breadcrumbs[0]).toBeInstanceOf(Array);
+            expect(page.props().breadcrumbs[0]).toHaveLength(2);
+            expect(page.props().breadcrumbs[0][0]).toBe(expectedCrumb[0][0]);
+            expect(page.props().breadcrumbs[0][1]).toBe(expectedCrumb[0][1]);
+        })
+        it("Contains 1 <HomePageContents/> component", ()=>{
+            expect(wrapper.find(HomePageContents)).toHaveLength(1);
+        })
+    })
+})

--- a/frontend/src/homepage/__tests__/HomePage.test.jsx
+++ b/frontend/src/homepage/__tests__/HomePage.test.jsx
@@ -8,28 +8,27 @@ import Page from "../../general/Page";
 
 Enzyme.configure({ adapter: new Adapter() });
 
+describe("<HomePage/> functional component", () => {
+  let wrapper;
+  const expectedTitle = "Dashboard";
+  const expectedCrumb = [["Home", ""]];
+  describe("returns a component that", () => {
+    beforeEach(() => {
+      wrapper = Enzyme.shallow(<HomePage />);
+    });
+    it("contains 1 <Page/> component with the correct props", () => {
+      expect(wrapper.find(Page)).toHaveLength(1);
 
-describe("<HomePage/> functional component", ()=>{
-    let wrapper;
-    const expectedTitle = "Dashboard";
-    const expectedCrumb = [["Home", ""]];
-    describe("returns a component that", ()=>{
-        beforeEach(()=>{
-            wrapper = Enzyme.shallow(<HomePage/>);
-        })
-        it("contains 1 <Page/> component with the correct props", ()=>{
-            expect(wrapper.find(Page)).toHaveLength(1);
-            
-            const page= wrapper.find(Page).first();
-            expect(page.props().title).toBe(expectedTitle);
-            expect(page.props().breadcrumbs).toBeInstanceOf(Array);
-            expect(page.props().breadcrumbs[0]).toBeInstanceOf(Array);
-            expect(page.props().breadcrumbs[0]).toHaveLength(2);
-            expect(page.props().breadcrumbs[0][0]).toBe(expectedCrumb[0][0]);
-            expect(page.props().breadcrumbs[0][1]).toBe(expectedCrumb[0][1]);
-        })
-        it("Contains 1 <HomePageContents/> component", ()=>{
-            expect(wrapper.find(HomePageContents)).toHaveLength(1);
-        })
-    })
-})
+      const page = wrapper.find(Page).first();
+      expect(page.props().title).toBe(expectedTitle);
+      expect(page.props().breadcrumbs).toBeInstanceOf(Array);
+      expect(page.props().breadcrumbs[0]).toBeInstanceOf(Array);
+      expect(page.props().breadcrumbs[0]).toHaveLength(2);
+      expect(page.props().breadcrumbs[0][0]).toBe(expectedCrumb[0][0]);
+      expect(page.props().breadcrumbs[0][1]).toBe(expectedCrumb[0][1]);
+    });
+    it("Contains 1 <HomePageContents/> component", () => {
+      expect(wrapper.find(HomePageContents)).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/src/homepage/__tests__/HomePageContents.test.jsx
+++ b/frontend/src/homepage/__tests__/HomePageContents.test.jsx
@@ -2,10 +2,9 @@ import React from "react";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { describe, expect, it } from "@jest/globals";
-import { Box, Container, Grid } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
 import HomePageContents from "../HomePageContents";
 
-import DynamicBreadcrumb from "../../general/DynamicBreadcrumb";
 import GridColumn from "../../general/dashboard/GridColumn";
 import AdminPanelCard from "../AdminPanelCard";
 import ActiveStreamCard from "../ActiveStreamCard";
@@ -76,16 +75,6 @@ describe("<HomePage/> functional component", () => {
     const expectedWidth = 6;
 
     expect(gridColumn.props().width).toBe(expectedWidth);
-  });
-  it("Contains 1 <DynamicBreadcrumb/> Component that has expected props", () => {
-    expect(wrapper.find(DynamicBreadcrumb)).toHaveLength(1);
-    const breadcrumbs = wrapper.find(DynamicBreadcrumb).first();
-    const expectedCrumb = [["Home", ""]];
-    expect(breadcrumbs.props().breadcrumbs).toHaveLength(1);
-    const innerCrumb = breadcrumbs.props().breadcrumbs[0];
-    expect(innerCrumb).toHaveLength(2);
-    expect(innerCrumb[0]).toBe(expectedCrumb[0][0]);
-    expect(innerCrumb[1]).toBe(expectedCrumb[0][1]);
   });
   it("Contains 1 <ActiveStreamCard/>", () => {
     expect(wrapper.find(ActiveStreamCard)).toHaveLength(1);

--- a/frontend/src/homepage/__tests__/HomePageContents.test.jsx
+++ b/frontend/src/homepage/__tests__/HomePageContents.test.jsx
@@ -3,7 +3,7 @@ import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { describe, expect, it } from "@jest/globals";
 import { Box, Container, Grid } from "@material-ui/core";
-import HomePage from "../HomePage";
+import HomePageContents from "../HomePageContents";
 
 import DynamicBreadcrumb from "../../general/DynamicBreadcrumb";
 import GridColumn from "../../general/dashboard/GridColumn";
@@ -14,7 +14,7 @@ import DevicesCard from "../DevicesCard";
 
 Enzyme.configure({ adapter: new Adapter() });
 describe("<HomePage/> functional component", () => {
-  const wrapper = Enzyme.shallow(<HomePage />);
+  const wrapper = Enzyme.shallow(<HomePageContents />);
   it("Contains 6 <Grid/> components", () => {
     expect(wrapper.find(Grid)).toHaveLength(6);
   });
@@ -86,12 +86,6 @@ describe("<HomePage/> functional component", () => {
     expect(innerCrumb).toHaveLength(2);
     expect(innerCrumb[0]).toBe(expectedCrumb[0][0]);
     expect(innerCrumb[1]).toBe(expectedCrumb[0][1]);
-  });
-  it("Contains 1 <Container/>", () => {
-    expect(wrapper.find(Container)).toHaveLength(1);
-  });
-  it("Contains 1 <Box/>", () => {
-    expect(wrapper.find(Box)).toHaveLength(1);
   });
   it("Contains 1 <ActiveStreamCard/>", () => {
     expect(wrapper.find(ActiveStreamCard)).toHaveLength(1);

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import HeaderBar from "./general/HeaderBar";
-import HomePage from "./homepage/HomePage";
+import HomePageContents from "./homepage/HomePageContents";
 import DeviceListPage from "./devicelist/DeviceListPage";
 import StreamingTablePage from "./createStream/StreamingPage";
 import DeviceDetailsPage from "./deviceDetailsPage/DeviceDetailsPage";
@@ -19,7 +19,7 @@ ReactDOM.render(
     <BrowserRouter>
       <HeaderBar />
       <Switch>
-        <Route exact path={["/", "/Home"]} component={HomePage} />
+        <Route exact path={["/", "/Home"]} component={HomePageContents} />
         <Route
           exact
           path="/Devices"

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import HeaderBar from "./general/HeaderBar";
-import HomePageContents from "./homepage/HomePageContents";
+import HomePage from "./homepage/HomePage";
 import DeviceListPage from "./devicelist/DeviceListPage";
 import StreamingTablePage from "./createStream/StreamingPage";
 import DeviceDetailsPage from "./deviceDetailsPage/DeviceDetailsPage";
@@ -19,7 +19,7 @@ ReactDOM.render(
     <BrowserRouter>
       <HeaderBar />
       <Switch>
-        <Route exact path={["/", "/Home"]} component={HomePageContents} />
+        <Route exact path={["/", "/Home"]} component={HomePage} />
         <Route
           exact
           path="/Devices"


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: Closes #346 

**Task description**: 

 - Move HomePage to Page component
 - contents is now called HomePageContents

# Additional notes

**Note to reviewers**:
Yes, it's normal to have two headerbars. The extra headerbar is from the Index.js page where we render a headerbar regardless of whether or not we are logged in. That entire file is being rewritten so I ddin't bother remove it for this PR, but you can check for yourself by removing the line

**To do before merging**:
- [ ] Edit Changelog(if necessary)
