### PR TITLE
[#370] Add alignment and spacing to breadcrumbs/title

### DIFF
--- a/frontend/src/general/Page.jsx
+++ b/frontend/src/general/Page.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Container } from "@material-ui/core";
+import { Box, Container } from "@material-ui/core";
 import DynamicBreadcrumb from "./DynamicBreadcrumb";
 import Title from "./Title";
 import HeaderBar from "./HeaderBar";
@@ -12,8 +12,10 @@ export default function Page(props) {
       <HeaderBar />
       <Container>
         <DynamicBreadcrumb breadcrumbs={breadcrumbs} />
-        <Title title={title} deviceList={deviceList} />
-        {children}
+        <Box className="areaUnderBreadcrumbs">
+          <Title title={title} deviceList={deviceList} />
+          {children}
+        </Box>
       </Container>
     </>
   );

--- a/frontend/src/general/__tests__/Page.test.jsx
+++ b/frontend/src/general/__tests__/Page.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { beforeAll, describe, expect, it } from "@jest/globals";
-import { Container } from "@material-ui/core";
+import { Box, Container } from "@material-ui/core";
 import Page from "../Page";
 
 import Title from "../Title";
@@ -38,6 +38,10 @@ describe("<Title/> functional Component", () => {
         const crumb = wrapper.find(DynamicBreadcrumb).first();
         expect(crumb.props().breadcrumbs[0][0]).toBe(dummyCrumb[0][0]);
         expect(crumb.props().breadcrumbs[0][1]).toBe(dummyCrumb[0][1]);
+      });
+      it("Contains 1 <Box/> component with areaUnderBreacrumbs styling", () => {
+        expect(wrapper.find(Box)).toHaveLength(1);
+        expect(wrapper.find(Box).hasClass("areaUnderBreadcrumbs")).toBe(true);
       });
       it("Contains 1 <Title/> component with expected props", () => {
         expect(wrapper.find(Title)).toHaveLength(1);


### PR DESCRIPTION
# General info

**Issue number**: #370

**Task description**: 
- Align breadcrumbs and page title
- Add spacing between breadcrumbs and page title
 
<!-- What changed? What does this do? Provide screenshots if necessary--> 
| Original   | Updated|
|:---------------:|:---------------:|
|![image](https://user-images.githubusercontent.com/33813045/110230666-868b9200-7ee0-11eb-9f72-2c95ebe6b552.png)|![image](https://user-images.githubusercontent.com/33813045/110230677-96a37180-7ee0-11eb-86ff-f16f2dc9d080.png)|

# Testing

**Test coverage**: N/A

# Additional notes

**Note to reviewers**:
N/A

**To do before merging**:
N/A
