### PR TITLE
[#374] Refactor StreamInfo to add channels

### DIFF
--- a/frontend/src/api/SampleData.js
+++ b/frontend/src/api/SampleData.js
@@ -391,15 +391,9 @@ export function getAllStreams() {
   ];
 
   return [
-    new StreamInfo(1, sampleSenders[0], sampleReceivers[0], [
-      "Additional Stream Details go here"
-    ]),
-    new StreamInfo(2, sampleSenders[1], sampleReceivers[1], [
-      "Additional Stream Details go here"
-    ]),
-    new StreamInfo(3, sampleSenders[1], sampleReceivers[0], [
-      "Additional Stream Details go here"
-    ])
+    new StreamInfo(1, sampleSenders[0], sampleReceivers[0]),
+    new StreamInfo(2, sampleSenders[1], sampleReceivers[1]),
+    new StreamInfo(3, sampleSenders[1], sampleReceivers[0])
   ];
 }
 

--- a/frontend/src/api/StreamApi.js
+++ b/frontend/src/api/StreamApi.js
@@ -10,8 +10,7 @@ export async function getStream(streamId) {
       return new StreamInfo(
         stream.id,
         convertToDataObject(stream.outputChannel.encoder),
-        convertToDataObject(stream.inputChannel.decoder),
-        ["Additional stream info goes here."]
+        convertToDataObject(stream.inputChannel.decoder)
       );
     });
 }

--- a/frontend/src/api/StreamApi.js
+++ b/frontend/src/api/StreamApi.js
@@ -10,7 +10,9 @@ export async function getStream(streamId) {
       return new StreamInfo(
         stream.id,
         convertToDataObject(stream.outputChannel.encoder),
-        convertToDataObject(stream.inputChannel.decoder)
+        convertToDataObject(stream.inputChannel.decoder),
+        stream.outputChannel.channel.port,
+        stream.inputChannel.channel.port
       );
     });
 }

--- a/frontend/src/api/tests/StreamApi.test.js
+++ b/frontend/src/api/tests/StreamApi.test.js
@@ -20,14 +20,12 @@ const {
 const expectedFirstStreamRespone = new StreamInfo(
   1,
   convertToDataObject(firstStreamResponse.outputChannel.encoder),
-  convertToDataObject(firstStreamResponse.inputChannel.decoder),
-  ["Additional stream info goes here."]
+  convertToDataObject(firstStreamResponse.inputChannel.decoder)
 );
 const expectedSecondStreamResponse = new StreamInfo(
   2,
   convertToDataObject(secondStreamResponse.outputChannel.encoder),
-  convertToDataObject(secondStreamResponse.inputChannel.decoder),
-  ["Additional stream info goes here."]
+  convertToDataObject(secondStreamResponse.inputChannel.decoder)
 );
 
 const expectedAllStreamsResponse = [

--- a/frontend/src/api/tests/StreamApi.test.js
+++ b/frontend/src/api/tests/StreamApi.test.js
@@ -20,12 +20,16 @@ const {
 const expectedFirstStreamRespone = new StreamInfo(
   1,
   convertToDataObject(firstStreamResponse.outputChannel.encoder),
-  convertToDataObject(firstStreamResponse.inputChannel.decoder)
+  convertToDataObject(firstStreamResponse.inputChannel.decoder),
+  20001,
+  20002
 );
 const expectedSecondStreamResponse = new StreamInfo(
   2,
   convertToDataObject(secondStreamResponse.outputChannel.encoder),
-  convertToDataObject(secondStreamResponse.inputChannel.decoder)
+  convertToDataObject(secondStreamResponse.inputChannel.decoder),
+  20000,
+  20003
 );
 
 const expectedAllStreamsResponse = [

--- a/frontend/src/createStream/CreateStreamPage.jsx
+++ b/frontend/src/createStream/CreateStreamPage.jsx
@@ -7,7 +7,7 @@ export default function CreateStreamPage(props) {
   const { dataSource } = props;
   const breadcrumbs = [
     ["Home", "/Home"],
-    ["My Streams", "/Streaming"],
+    ["Active Streams", "/Streaming"],
     ["New Stream", "/Streaming/New"]
   ];
   return (

--- a/frontend/src/createStream/__tests__/CreateStreamPage.test.jsx
+++ b/frontend/src/createStream/__tests__/CreateStreamPage.test.jsx
@@ -17,7 +17,7 @@ describe("<CreateStreamPage/> functional Component", () => {
       const expectedTitle = "Create a Stream";
       const expectedCrumb = [
         ["Home", "/Home"],
-        ["My Streams", "/Streaming"],
+        ["Active Streams", "/Streaming"],
         ["New Stream", "/Streaming/New"]
       ];
 

--- a/frontend/src/model/StreamInfo.js
+++ b/frontend/src/model/StreamInfo.js
@@ -12,7 +12,7 @@ export default class StreamInfo {
   // }
 
   // temporary with static fields until backend is up to snuff
-  constructor(id, sender, receiver, extras) {
+  constructor(id, sender, receiver, outputChannel, inputChannel) {
     this.id = id;
     this.date = new Date("2020-10-31T08:15:30")
       .toString()
@@ -21,6 +21,8 @@ export default class StreamInfo {
       .join(" ");
     this.sender = sender;
     this.receiver = receiver;
+    this.outputChannel = outputChannel;
+    this.inputChannel = inputChannel;
     this.status = "Online";
     this.type = "Type 1";
     this.time = "00:34:44";

--- a/frontend/src/model/StreamInfo.js
+++ b/frontend/src/model/StreamInfo.js
@@ -24,6 +24,5 @@ export default class StreamInfo {
     this.status = "Online";
     this.type = "Type 1";
     this.time = "00:34:44";
-    this.extras = extras;
   }
 }

--- a/frontend/src/streamlist/StreamsTable.jsx
+++ b/frontend/src/streamlist/StreamsTable.jsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { Box, TableContainer, Typography } from "@material-ui/core";
+import { Box, TableContainer } from "@material-ui/core";
 import PropTypes from "prop-types";
 
 import {
-  ExpandLess,
-  ExpandMore,
   ArrowDownward,
   FirstPage,
   LastPage,
@@ -87,7 +85,6 @@ export default class StreamsTable extends React.Component {
   getColumnInfo() {
     return this.columnInfo;
   }
-
 
   getOptions() {
     return this.options;

--- a/frontend/src/streamlist/StreamsTable.jsx
+++ b/frontend/src/streamlist/StreamsTable.jsx
@@ -66,20 +66,6 @@ export default class StreamsTable extends React.Component {
         export: false
       }
     ];
-    this.detailPanel = [
-      {
-        icon: ExpandMore,
-        openIcon: ExpandLess,
-        tooltip: "Show Stream Details",
-        render: function DetailPanel(rowData) {
-          return (
-            <div className="lightestGrey">
-              <Typography variant="h6">{rowData.extras}</Typography>
-            </div>
-          );
-        }
-      }
-    ];
     this.options = {
       toolbar: false,
       headerStyle: {
@@ -102,9 +88,6 @@ export default class StreamsTable extends React.Component {
     return this.columnInfo;
   }
 
-  getDetailPanel() {
-    return this.detailPanel;
-  }
 
   getOptions() {
     return this.options;
@@ -123,7 +106,6 @@ export default class StreamsTable extends React.Component {
             <MaterialTable
               columns={this.getColumnInfo()}
               data={streams}
-              detailPanel={this.getDetailPanel()}
               options={this.getOptions()}
               icons={this.getIcons()}
             />

--- a/frontend/src/streamlist/__tests__/StreamsTable.test.jsx
+++ b/frontend/src/streamlist/__tests__/StreamsTable.test.jsx
@@ -204,48 +204,6 @@ describe("<StreamsTable/> component", () => {
     });
   });
 
-  describe("getDetailPanel() function to return an array", () => {
-    const dummyStreams = [null];
-    wrapper = Enzyme.shallow(<StreamsTable streams={dummyStreams} />);
-    const result = wrapper.instance().getDetailPanel();
-    const getDetailPanelExpectedResult = [
-      {
-        icon: ExpandMore,
-        openIcon: ExpandLess,
-        tooltip: "Show Stream Details",
-        render: function DetailPanel(rowData) {
-          return (
-            <div className="lightestGrey">
-              <Typography variant="h6">{rowData.extras}</Typography>
-            </div>
-          );
-        }
-      }
-    ];
-    describe("containing a single object", () => {
-      expect(result.length).toBe(1);
-      expect(typeof result[0]).toBe("object");
-      it("has a property icon which has value ExpandMore", () => {
-        expect(result[0].icon).toBe(ExpandMore);
-      });
-      it("has a property openIcon which has value ExpandLess", () => {
-        expect(result[0].openIcon).toBe(ExpandLess);
-      });
-      it("has a property tooltip which has value: the expected message", () => {
-        expect(result[0].tooltip).toBe(getDetailPanelExpectedResult[0].tooltip);
-      });
-      it(`should have a render() function returns a predefined component`, () => {
-        const dummyData = {
-          extras: 444
-        };
-        const renderResult = result[0].render(dummyData);
-        expect(renderResult).toMatchObject(
-          getDetailPanelExpectedResult[0].render(dummyData)
-        );
-      });
-    });
-  });
-
   describe("getOptions() function", () => {
     const dummyStreams = [null];
     wrapper = Enzyme.shallow(<StreamsTable streams={dummyStreams} />);

--- a/frontend/src/streamlist/__tests__/StreamsTable.test.jsx
+++ b/frontend/src/streamlist/__tests__/StreamsTable.test.jsx
@@ -9,10 +9,8 @@ import {
   jest,
   it
 } from "@jest/globals";
-import { Box, TableContainer, Typography } from "@material-ui/core";
+import { Box, TableContainer } from "@material-ui/core";
 import {
-  ExpandLess,
-  ExpandMore,
   ArrowDownward,
   FirstPage,
   LastPage,


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: #374
**Task description**: 

 - update `StreamInfo` model & everything that used it
 - got rid of extras field since we really aren't planning to use it anytime soon
 - bonus: updated breadcrumb to have consistent name (`Active Streams`)
 
<!-- What changed? What does this do? Provide screenshots if necessary--> 
| Original   | Updated|
|:---------------:|:---------------:|
| ![image](https://user-images.githubusercontent.com/22307286/110422101-b8316400-806c-11eb-9e42-a57cc0a53520.png) | ![image](https://user-images.githubusercontent.com/22307286/110422286-11999300-806d-11eb-90a9-80866ee21a21.png) |
| ![image](https://user-images.githubusercontent.com/22307286/110422341-2c6c0780-806d-11eb-8825-4eff599d2b6a.png) | ![image](https://user-images.githubusercontent.com/22307286/110422314-21b17280-806d-11eb-8933-df0eb96fbe0b.png) |


# Testing

**Test coverage**:
- unchanged

# Additional notes

**Note to reviewers**:
<!-- Special instructions for testing this code-->
- done so that Stream Details Page (#266) can refer to the channels in use for streaming
