### PR TITLE
[Auth] Integrate protected routes with frontend auth 2

### DIFF
--- a/frontend/src/api/AuthenticationApi.js
+++ b/frontend/src/api/AuthenticationApi.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import Cookies from "js-cookie";
-import { saveToken } from "./AuthenticationUtil";
+import * as AuthenticationUtil from "./AuthenticationUtil";
 
 export const unknownErrorMessage =
   "An unknown error occurred. Please try again later.";
@@ -18,7 +18,7 @@ export async function logIn(credentials) {
   return axios
     .get(process.env.REACT_APP_TOKEN, authorizationHeader)
     .then((response) => {
-      saveToken(response.headers.authorization);
+      AuthenticationUtil.saveToken(response.headers.authorization);
     })
     .catch((error) => {
       let message = unknownErrorMessage;
@@ -29,55 +29,6 @@ export async function logIn(credentials) {
     });
 }
 
-export function getAccessToken() {
-  return Cookies.get("access_token");
-}
-
-export function getAdminToken() {
-  return Cookies.get("admin_token");
-}
-
-export function getRefreshToken() {
-  return Cookies.get("refresh_token");
-}
-
-export function isAuthenticated() {
-  return !!getAccessToken();
-}
-
-export function isAdmin() {
-  return !!getAdminToken();
-}
-
-export function handleLogout() {
-  // API call.then(response =>
-  Cookies.remove("access_token");
-  Cookies.remove("admin_token");
-  Cookies.remove("refresh_token");
-}
-
-export async function handleLogin() {
-  //   if (getRefreshToken()) {
-  try {
-    // const tokens = await refreshTokens() // call an API, returns tokens
-
-    const tokens = {
-      access_token: true,
-      admin_token: true,
-      refresh_token: true
-    };
-    const expires = (tokens.expires_in || 60 * 60) * 1000;
-    const inOneHour = new Date(new Date().getTime() + expires);
-
-    // you will have the exact same setters in your Login page/app too
-    Cookies.set("access_token", tokens.access_token, { expires: inOneHour });
-    Cookies.set("admin_token", tokens.admin_token, { expires: inOneHour });
-    Cookies.set("refresh_token", tokens.refresh_token, { expires: inOneHour });
-
-    return true;
-  } catch (error) {
-    return false;
-  }
-  // }
-  // return false;
+export function logOut() {
+  Cookies.remove("authToken");
 }

--- a/frontend/src/api/AuthenticationUtil.js
+++ b/frontend/src/api/AuthenticationUtil.js
@@ -7,7 +7,8 @@ function parseJwt(token) {
     atob(base64)
       .split("")
       .map((c) => {
-        return `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`;
+        const component = `00${c.charCodeAt(0).toString(16)}`;
+        return `%${component.slice(-2)}`;
       })
       .join("")
   );

--- a/frontend/src/api/AuthenticationUtil.js
+++ b/frontend/src/api/AuthenticationUtil.js
@@ -18,7 +18,7 @@ function parseJwt(token) {
 export function saveToken(token) {
   const tokenPayload = parseJwt(token.split(" ")[1]);
   const expiryDate = new Date(tokenPayload.exp * 1000);
-  Cookies.set("authToken", token, { expires: expiryDate });
+  Cookies.set("authToken", token, { expires: expiryDate, SameSite: "Strict" });
 }
 
 export function getAuthorizationHeader() {

--- a/frontend/src/api/AuthenticationUtil.js
+++ b/frontend/src/api/AuthenticationUtil.js
@@ -6,7 +6,7 @@ function parseJwt(token) {
   const jsonPayload = decodeURIComponent(
     atob(base64)
       .split("")
-      .map(function (c) {
+      .map((c) => {
         return `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`;
       })
       .join("")

--- a/frontend/src/api/AuthenticationUtil.js
+++ b/frontend/src/api/AuthenticationUtil.js
@@ -36,7 +36,7 @@ export function isAuthenticated() {
 export function isAdmin() {
   const token = Cookies.get("authToken");
   const tokenPayload = parseJwt(token.split(" ")[1]);
-  return tokenPayload.sub === "admin";
+  return tokenPayload.role === "ADMIN" || tokenPayload.role === "SUPERUSER";
 }
 
 export default {

--- a/frontend/src/api/AuthenticationUtil.js
+++ b/frontend/src/api/AuthenticationUtil.js
@@ -1,12 +1,41 @@
+import Cookies from "js-cookie";
+
+function parseJwt(token) {
+  const base64Url = token.split(".")[1];
+  const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split("")
+      .map(function (c) {
+        return `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`;
+      })
+      .join("")
+  );
+
+  return JSON.parse(jsonPayload);
+}
+
 export function saveToken(token) {
-  localStorage.setItem("authToken", token);
+  const tokenPayload = parseJwt(token.split(" ")[1]);
+  const expiryDate = new Date(tokenPayload.exp * 1000);
+  Cookies.set("authToken", token, { expires: expiryDate });
 }
 
 export function getAuthorizationHeader() {
-  const token = localStorage.getItem("authToken");
+  const token = Cookies.get("authToken");
   return {
     headers: { Authorization: `${token}` }
   };
+}
+
+export function isAuthenticated() {
+  return !!Cookies.get("authToken");
+}
+
+export function isAdmin() {
+  const token = Cookies.get("authToken");
+  const tokenPayload = parseJwt(token.split(" ")[1]);
+  return tokenPayload.sub === "admin";
 }
 
 export default {

--- a/frontend/src/api/LogApi.js
+++ b/frontend/src/api/LogApi.js
@@ -26,5 +26,8 @@ export async function getAllLogs() {
 }
 
 export async function getDeviceLogs(deviceSerialNumber) {
-  return getLogs(`${process.env.REACT_APP_LOGS}/${deviceSerialNumber}`, getAuthorizationHeader());
+  return getLogs(
+    `${process.env.REACT_APP_LOGS}/${deviceSerialNumber}`,
+    getAuthorizationHeader()
+  );
 }

--- a/frontend/src/api/LogApi.js
+++ b/frontend/src/api/LogApi.js
@@ -26,7 +26,5 @@ export async function getAllLogs() {
 }
 
 export async function getDeviceLogs(deviceSerialNumber) {
-  return getLogs(
-    `${process.env.REACT_APP_LOGS}/${deviceSerialNumber}`
-  );
+  return getLogs(`${process.env.REACT_APP_LOGS}/${deviceSerialNumber}`);
 }

--- a/frontend/src/api/LogApi.js
+++ b/frontend/src/api/LogApi.js
@@ -2,7 +2,6 @@ import axios from "axios";
 import LogInfo from "../model/LogInfo";
 import { getAuthorizationHeader } from "./AuthenticationUtil";
 import * as SampleData from "./SampleData";
-import { getAuthorizationHeader } from "./AuthenticationUtil";
 
 async function getLogs(endpoint) {
   return axios

--- a/frontend/src/api/LogApi.js
+++ b/frontend/src/api/LogApi.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import LogInfo from "../model/LogInfo";
+import { getAuthorizationHeader } from "./AuthenticationUtil";
 import * as SampleData from "./SampleData";
 import { getAuthorizationHeader } from "./AuthenticationUtil";
 
@@ -21,9 +22,9 @@ async function getLogs(endpoint) {
 }
 
 export async function getAllLogs() {
-  return getLogs(process.env.REACT_APP_LOG);
+  return getLogs(process.env.REACT_APP_LOGS, getAuthorizationHeader());
 }
 
 export async function getDeviceLogs(deviceSerialNumber) {
-  return getLogs(`${process.env.REACT_APP_LOG}/${deviceSerialNumber}`);
+  return getLogs(`${process.env.REACT_APP_LOGS}/${deviceSerialNumber}`, getAuthorizationHeader());
 }

--- a/frontend/src/api/LogApi.js
+++ b/frontend/src/api/LogApi.js
@@ -22,12 +22,11 @@ async function getLogs(endpoint) {
 }
 
 export async function getAllLogs() {
-  return getLogs(process.env.REACT_APP_LOGS, getAuthorizationHeader());
+  return getLogs(process.env.REACT_APP_LOGS);
 }
 
 export async function getDeviceLogs(deviceSerialNumber) {
   return getLogs(
-    `${process.env.REACT_APP_LOGS}/${deviceSerialNumber}`,
-    getAuthorizationHeader()
+    `${process.env.REACT_APP_LOGS}/${deviceSerialNumber}`
   );
 }

--- a/frontend/src/api/LogApi.js
+++ b/frontend/src/api/LogApi.js
@@ -21,9 +21,9 @@ async function getLogs(endpoint) {
 }
 
 export async function getAllLogs() {
-  return getLogs(process.env.REACT_APP_LOGS);
+  return getLogs(process.env.REACT_APP_LOG);
 }
 
 export async function getDeviceLogs(deviceSerialNumber) {
-  return getLogs(`${process.env.REACT_APP_LOGS}/${deviceSerialNumber}`);
+  return getLogs(`${process.env.REACT_APP_LOG}/${deviceSerialNumber}`);
 }

--- a/frontend/src/api/tests/AuthenticationApi.test.js
+++ b/frontend/src/api/tests/AuthenticationApi.test.js
@@ -5,16 +5,12 @@ import * as AuthenticationUtil from "../AuthenticationUtil";
 import * as AuthenticationApi from "../AuthenticationApi";
 
 jest.mock("axios");
-jest.mock("js-cookie");
-jest.spyOn(Cookies, "get");
-jest.spyOn(Cookies, "set");
-jest.spyOn(Cookies, "remove");
 jest.mock("../AuthenticationUtil");
 jest.spyOn(AuthenticationUtil, "saveToken");
+jest.mock("js-cookie");
+jest.spyOn(Cookies, "remove");
 
 describe("AuthenticationApi", () => {
-  const dummyAuthToken = "authToken";
-
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -53,74 +49,12 @@ describe("AuthenticationApi", () => {
     });
   });
 
-  describe("isAuthenticated", () => {
-    it("should return true if auth token is defined", () => {
-      Cookies.get.mockReturnValue(dummyAuthToken);
-      const authenticated = AuthenticationApi.isAuthenticated();
-
-      expect(Cookies.get).toHaveBeenCalledWith("authToken");
-      expect(authenticated).toEqual(true);
-    });
-
-    it("should return false if auth token is undefined", () => {
-      Cookies.get.mockReturnValue(undefined);
-      const authenticated = AuthenticationApi.isAuthenticated();
-
-      expect(Cookies.get).toHaveBeenCalledWith("authToken");
-      expect(authenticated).toEqual(false);
-    });
-  });
-
-  describe("isAdmin", () => {
-    it("should ", () => {
-      Cookies.get.mockReturnValue(dummyAdminToken);
-      const admin = AuthenticationApi.isAdmin();
-
-      expect(Cookies.get).toHaveBeenCalledWith("admin_token");
-      expect(admin).toEqual(true);
-    });
-
-    it("should return false if access token is undefined", () => {
-      Cookies.get.mockReturnValue(undefined);
-      const admin = AuthenticationApi.isAdmin();
-
-      expect(Cookies.get).toHaveBeenCalledWith("admin_token");
-      expect(admin).toEqual(false);
-    });
-  });
-
-  describe("handleLogout() function", () => {
-    it("should call Cookies.remove() 3 times", () => {
+  describe("logOut() function", () => {
+    it("should call Cookies.remove() once", () => {
       AuthenticationApi.logOut();
 
-      expect(Cookies.remove).toBeCalledTimes(3);
-      expect(Cookies.remove.mock.calls[0][0]).toBe("access_token");
-      expect(Cookies.remove.mock.calls[1][0]).toBe("admin_token");
-      expect(Cookies.remove.mock.calls[2][0]).toBe("refresh_token");
+      expect(Cookies.remove).toHaveBeenCalledWith("authToken");
     });
   });
 
-  describe("handleLogin() function", () => {
-    it("should call Cookies.set 3 times with expected args & return true", async () => {
-      const expectedTokens = {
-        access_token: true,
-        admin_token: true,
-        refresh_token: true
-      };
-
-      const value = await AuthenticationApi.handleLogin();
-
-      expect(Cookies.set).toBeCalledTimes(3);
-      expect(Cookies.set.mock.calls[0][0]).toBe("access_token");
-      expect(Cookies.set.mock.calls[0][1]).toBe(expectedTokens.access_token);
-
-      expect(Cookies.set.mock.calls[1][0]).toBe("admin_token");
-      expect(Cookies.set.mock.calls[1][1]).toBe(expectedTokens.admin_token);
-
-      expect(Cookies.set.mock.calls[2][0]).toBe("refresh_token");
-      expect(Cookies.set.mock.calls[2][1]).toBe(expectedTokens.refresh_token);
-
-      expect(value).toBe(true);
-    });
-  });
 });

--- a/frontend/src/api/tests/AuthenticationApi.test.js
+++ b/frontend/src/api/tests/AuthenticationApi.test.js
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, jest } from "@jest/globals";
 import axios from "axios";
 import Cookies from "js-cookie";
-import { saveToken } from "../AuthenticationUtil";
+import * as AuthenticationUtil from "../AuthenticationUtil";
 import * as AuthenticationApi from "../AuthenticationApi";
 
 jest.mock("axios");
@@ -10,11 +10,10 @@ jest.spyOn(Cookies, "get");
 jest.spyOn(Cookies, "set");
 jest.spyOn(Cookies, "remove");
 jest.mock("../AuthenticationUtil");
+jest.spyOn(AuthenticationUtil, "saveToken");
 
 describe("AuthenticationApi", () => {
-  const dummyAccessToken = "dummyAccessToken";
-  const dummyAdminToken = "dummyAdminToken";
-  const dummyRefreshToken = "dummyRefreshToken";
+  const dummyAuthToken = "authToken";
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -41,69 +40,39 @@ describe("AuthenticationApi", () => {
       ).rejects.toEqual(new Error(AuthenticationApi.unknownErrorMessage));
     });
 
-    it("should save token in localstorage", async () => {
-      const expectedToken = "Bearer the_token";
+    it("should save token using AuthenticationUtil", async () => {
+      const dummyAuthorizationHeader = "Bearer the_token";
       axios.get.mockResolvedValue({
         headers: {
-          authorization: expectedToken
+          authorization: dummyAuthorizationHeader
         }
       });
       await AuthenticationApi.logIn({ username: "user", password: "pass" });
 
-      expect(saveToken).toHaveBeenCalledWith(expectedToken);
-    });
-  });
-
-  describe("getAccessToken", () => {
-    it("should call Cookies.get and return the access token", () => {
-      Cookies.get.mockReturnValue(dummyAccessToken);
-      const token = AuthenticationApi.getAccessToken();
-
-      expect(Cookies.get).toHaveBeenCalledWith("access_token");
-      expect(token).toEqual(dummyAccessToken);
-    });
-  });
-
-  describe("getAdminToken", () => {
-    it("should call Cookies.get and return the admin token", () => {
-      Cookies.get.mockReturnValue(dummyAdminToken);
-      const token = AuthenticationApi.getAdminToken();
-
-      expect(Cookies.get).toHaveBeenCalledWith("admin_token");
-      expect(token).toEqual(dummyAdminToken);
-    });
-  });
-
-  describe("getRefreshToken", () => {
-    it("should call Cookies.get and return the refresh token", () => {
-      Cookies.get.mockReturnValue(dummyRefreshToken);
-      const token = AuthenticationApi.getRefreshToken();
-
-      expect(Cookies.get).toHaveBeenCalledWith("refresh_token");
-      expect(token).toEqual(dummyRefreshToken);
+      expect(AuthenticationUtil.saveToken).toHaveBeenCalledWith(dummyAuthorizationHeader);
     });
   });
 
   describe("isAuthenticated", () => {
-    it("should return true if access token is defined", () => {
-      Cookies.get.mockReturnValue(dummyAccessToken);
+    it("should return true if auth token is defined", () => {
+      Cookies.get.mockReturnValue(dummyAuthToken);
       const authenticated = AuthenticationApi.isAuthenticated();
 
-      expect(Cookies.get).toHaveBeenCalledWith("access_token");
+      expect(Cookies.get).toHaveBeenCalledWith("authToken");
       expect(authenticated).toEqual(true);
     });
 
-    it("should return false if access token is undefined", () => {
+    it("should return false if auth token is undefined", () => {
       Cookies.get.mockReturnValue(undefined);
       const authenticated = AuthenticationApi.isAuthenticated();
 
-      expect(Cookies.get).toHaveBeenCalledWith("access_token");
+      expect(Cookies.get).toHaveBeenCalledWith("authToken");
       expect(authenticated).toEqual(false);
     });
   });
 
   describe("isAdmin", () => {
-    it("should return true if admin token is defined", () => {
+    it("should ", () => {
       Cookies.get.mockReturnValue(dummyAdminToken);
       const admin = AuthenticationApi.isAdmin();
 
@@ -122,7 +91,7 @@ describe("AuthenticationApi", () => {
 
   describe("handleLogout() function", () => {
     it("should call Cookies.remove() 3 times", () => {
-      AuthenticationApi.handleLogout();
+      AuthenticationApi.logOut();
 
       expect(Cookies.remove).toBeCalledTimes(3);
       expect(Cookies.remove.mock.calls[0][0]).toBe("access_token");

--- a/frontend/src/api/tests/AuthenticationApi.test.js
+++ b/frontend/src/api/tests/AuthenticationApi.test.js
@@ -45,7 +45,9 @@ describe("AuthenticationApi", () => {
       });
       await AuthenticationApi.logIn({ username: "user", password: "pass" });
 
-      expect(AuthenticationUtil.saveToken).toHaveBeenCalledWith(dummyAuthorizationHeader);
+      expect(AuthenticationUtil.saveToken).toHaveBeenCalledWith(
+        dummyAuthorizationHeader
+      );
     });
   });
 
@@ -56,5 +58,4 @@ describe("AuthenticationApi", () => {
       expect(Cookies.remove).toHaveBeenCalledWith("authToken");
     });
   });
-
 });

--- a/frontend/src/api/tests/AuthenticationUtil.test.js
+++ b/frontend/src/api/tests/AuthenticationUtil.test.js
@@ -1,30 +1,76 @@
-import { afterEach, describe } from "@jest/globals";
-import { getAuthorizationHeader, saveToken } from "../AuthenticationUtil";
+import { afterEach, describe, expect, jest } from "@jest/globals";
+import Cookies from "js-cookie";
+import * as AuthenticationUtil from "../AuthenticationUtil";
+
+const dummyToken = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTYxNTU2ODI1M30.FwKJDZnHUaO3Z7m37xe7eahvP-Q5MqxpCDXMdEyTZ7reOtoHQBvIi7LoE4OeXds5qUb1vUfEMS1jzUbAvwmQ3A";
+const dummyTokenExpiry = new Date(1615568253000);
+const dummyTokenNotAdmin = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyIiwiZXhwIjoxNjE1NTY4MjUzfQ.FwKJDZnHUaO3Z7m37xe7eahvP-Q5MqxpCDXMdEyTZ7reOtoHQBvIi7LoE4OeXds5qUb1vUfEMS1jzUbAvwmQ3A";
+
+jest.mock("js-cookie");
+jest.spyOn(Cookies, "get");
+jest.spyOn(Cookies, "set");
+jest.spyOn(Cookies, "remove");
 
 describe("AuthenticationUtil", () => {
   afterEach(() => {
-    localStorage.clear();
+    jest.clearAllMocks();
   });
 
   describe("saveToken", () => {
     it("should save the token to local storage", () => {
-      const expectedToken = "token";
-      saveToken(expectedToken);
-      expect(localStorage.getItem("authToken")).toEqual(expectedToken);
+      AuthenticationUtil.saveToken(dummyToken);
+      expect(Cookies.set).toHaveBeenCalledWith("authToken", dummyToken, {expires: dummyTokenExpiry});
     });
   });
 
   describe("getAuthorizationHeader", () => {
     it("should get the correct authorization header", () => {
-      const token = "token";
       const expectedHeader = {
-        headers: { Authorization: `${token}` }
+        headers: { Authorization: `${dummyToken}` }
       };
-      localStorage.setItem("authToken", token);
+      Cookies.get.mockReturnValue(dummyToken);
 
-      const result = getAuthorizationHeader();
+      const result = AuthenticationUtil.getAuthorizationHeader();
 
       expect(result).toEqual(expectedHeader);
+      expect(Cookies.get).toHaveBeenCalledWith("authToken");
+    });
+  });
+
+  describe("isAuthenticated", () => {
+    it("should return true if auth token is defined", () => {
+      Cookies.get.mockReturnValue(dummyToken);
+      const authenticated = AuthenticationUtil.isAuthenticated();
+
+      expect(Cookies.get).toHaveBeenCalledWith("authToken");
+      expect(authenticated).toEqual(true);
+    });
+
+    it("should return false if auth token is undefined", () => {
+      Cookies.get.mockReturnValue(undefined);
+      const authenticated = AuthenticationUtil.isAuthenticated();
+
+      expect(Cookies.get).toHaveBeenCalledWith("authToken");
+      expect(authenticated).toEqual(false);
+    });
+  });
+
+  
+  describe("isAdmin", () => {
+    it("should return true if jwt token has role admin", () => {
+      Cookies.get.mockReturnValue(dummyToken);
+      const admin = AuthenticationUtil.isAdmin();
+
+      expect(Cookies.get).toHaveBeenCalledWith("authToken");
+      expect(admin).toEqual(true);
+    });
+
+    it("should return false if jwt token does not have role admin", () => {
+      Cookies.get.mockReturnValue(dummyTokenNotAdmin);
+      const admin = AuthenticationUtil.isAdmin();
+
+      expect(Cookies.get).toHaveBeenCalledWith("authToken");
+      expect(admin).toEqual(false);
     });
   });
 });

--- a/frontend/src/api/tests/AuthenticationUtil.test.js
+++ b/frontend/src/api/tests/AuthenticationUtil.test.js
@@ -22,7 +22,7 @@ describe("AuthenticationUtil", () => {
     it("should save the token to local storage", () => {
       AuthenticationUtil.saveToken(dummyToken);
       expect(Cookies.set).toHaveBeenCalledWith("authToken", dummyToken, {
-        expires: dummyTokenExpiry
+        expires: dummyTokenExpiry, SameSite: "Strict"
       });
     });
   });

--- a/frontend/src/api/tests/AuthenticationUtil.test.js
+++ b/frontend/src/api/tests/AuthenticationUtil.test.js
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, jest } from "@jest/globals";
 import Cookies from "js-cookie";
 import * as AuthenticationUtil from "../AuthenticationUtil";
 
-const dummyToken = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTYxNTU2ODI1M30.FwKJDZnHUaO3Z7m37xe7eahvP-Q5MqxpCDXMdEyTZ7reOtoHQBvIi7LoE4OeXds5qUb1vUfEMS1jzUbAvwmQ3A";
+const dummyToken =
+  "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTYxNTU2ODI1M30.FwKJDZnHUaO3Z7m37xe7eahvP-Q5MqxpCDXMdEyTZ7reOtoHQBvIi7LoE4OeXds5qUb1vUfEMS1jzUbAvwmQ3A";
 const dummyTokenExpiry = new Date(1615568253000);
-const dummyTokenNotAdmin = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyIiwiZXhwIjoxNjE1NTY4MjUzfQ.FwKJDZnHUaO3Z7m37xe7eahvP-Q5MqxpCDXMdEyTZ7reOtoHQBvIi7LoE4OeXds5qUb1vUfEMS1jzUbAvwmQ3A";
+const dummyTokenNotAdmin =
+  "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyIiwiZXhwIjoxNjE1NTY4MjUzfQ.FwKJDZnHUaO3Z7m37xe7eahvP-Q5MqxpCDXMdEyTZ7reOtoHQBvIi7LoE4OeXds5qUb1vUfEMS1jzUbAvwmQ3A";
 
 jest.mock("js-cookie");
 jest.spyOn(Cookies, "get");
@@ -19,7 +21,9 @@ describe("AuthenticationUtil", () => {
   describe("saveToken", () => {
     it("should save the token to local storage", () => {
       AuthenticationUtil.saveToken(dummyToken);
-      expect(Cookies.set).toHaveBeenCalledWith("authToken", dummyToken, {expires: dummyTokenExpiry});
+      expect(Cookies.set).toHaveBeenCalledWith("authToken", dummyToken, {
+        expires: dummyTokenExpiry
+      });
     });
   });
 
@@ -55,7 +59,6 @@ describe("AuthenticationUtil", () => {
     });
   });
 
-  
   describe("isAdmin", () => {
     it("should return true if jwt token has role admin", () => {
       Cookies.get.mockReturnValue(dummyToken);

--- a/frontend/src/api/tests/AuthenticationUtil.test.js
+++ b/frontend/src/api/tests/AuthenticationUtil.test.js
@@ -22,7 +22,8 @@ describe("AuthenticationUtil", () => {
     it("should save the token to local storage", () => {
       AuthenticationUtil.saveToken(dummyToken);
       expect(Cookies.set).toHaveBeenCalledWith("authToken", dummyToken, {
-        expires: dummyTokenExpiry, SameSite: "Strict"
+        expires: dummyTokenExpiry,
+        SameSite: "Strict"
       });
     });
   });

--- a/frontend/src/api/tests/AuthenticationUtil.test.js
+++ b/frontend/src/api/tests/AuthenticationUtil.test.js
@@ -7,7 +7,8 @@ const dummySuperuserToken =
 const dummyTokenExpiry = new Date(1615667806000);
 const dummyUserToken =
   "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0YWtvbyIsInJvbGUiOiJVU0VSIiwiZXhwIjoxNjE1NjY3ODQzfQ.ZREE9nlhA0706bxdWvSjne2K4pivSJDUN_1SY5YNhh4SR-6RPXXLEpqVMHnfT9tZxLiJZ8YCdRvgA6wxhX-dSw";
-const dummyAdminToken = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJub2dnIiwicm9sZSI6IkFETUlOIiwiZXhwIjoxNjE1NjY3ODY2fQ.rxXWY5gwPtt0wu_1Qcaedp-rNZnCWP95aLq9LHGF7I8InO3N_2CV25Jhf1o84wc7slgqyMV9lFROEiVFUvDMAg";
+const dummyAdminToken =
+  "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJub2dnIiwicm9sZSI6IkFETUlOIiwiZXhwIjoxNjE1NjY3ODY2fQ.rxXWY5gwPtt0wu_1Qcaedp-rNZnCWP95aLq9LHGF7I8InO3N_2CV25Jhf1o84wc7slgqyMV9lFROEiVFUvDMAg";
 
 jest.mock("js-cookie");
 jest.spyOn(Cookies, "get");
@@ -22,10 +23,14 @@ describe("AuthenticationUtil", () => {
   describe("saveToken", () => {
     it("should save the token in a cookie", () => {
       AuthenticationUtil.saveToken(dummySuperuserToken);
-      expect(Cookies.set).toHaveBeenCalledWith("authToken", dummySuperuserToken, {
-        expires: dummyTokenExpiry,
-        SameSite: "Strict"
-      });
+      expect(Cookies.set).toHaveBeenCalledWith(
+        "authToken",
+        dummySuperuserToken,
+        {
+          expires: dummyTokenExpiry,
+          SameSite: "Strict"
+        }
+      );
     });
   });
 
@@ -71,12 +76,12 @@ describe("AuthenticationUtil", () => {
     });
 
     it("should return true if jwt token has role ADMIN", () => {
-        Cookies.get.mockReturnValue(dummyAdminToken);
-        const admin = AuthenticationUtil.isAdmin();
-  
-        expect(Cookies.get).toHaveBeenCalledWith("authToken");
-        expect(admin).toEqual(true);
-      });
+      Cookies.get.mockReturnValue(dummyAdminToken);
+      const admin = AuthenticationUtil.isAdmin();
+
+      expect(Cookies.get).toHaveBeenCalledWith("authToken");
+      expect(admin).toEqual(true);
+    });
 
     it("should return false if jwt token has role USER", () => {
       Cookies.get.mockReturnValue(dummyUserToken);

--- a/frontend/src/api/tests/AuthenticationUtil.test.js
+++ b/frontend/src/api/tests/AuthenticationUtil.test.js
@@ -2,11 +2,12 @@ import { afterEach, describe, expect, jest } from "@jest/globals";
 import Cookies from "js-cookie";
 import * as AuthenticationUtil from "../AuthenticationUtil";
 
-const dummyToken =
-  "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbiIsImV4cCI6MTYxNTU2ODI1M30.FwKJDZnHUaO3Z7m37xe7eahvP-Q5MqxpCDXMdEyTZ7reOtoHQBvIi7LoE4OeXds5qUb1vUfEMS1jzUbAvwmQ3A";
-const dummyTokenExpiry = new Date(1615568253000);
-const dummyTokenNotAdmin =
-  "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyIiwiZXhwIjoxNjE1NTY4MjUzfQ.FwKJDZnHUaO3Z7m37xe7eahvP-Q5MqxpCDXMdEyTZ7reOtoHQBvIi7LoE4OeXds5qUb1vUfEMS1jzUbAvwmQ3A";
+const dummySuperuserToken =
+  "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhZG1pbiIsInJvbGUiOiJTVVBFUlVTRVIiLCJleHAiOjE2MTU2Njc4MDZ9.qYoS92pZ9qRqbLQ3LfUbWUgNCQ30KvEV3TP65RSA5piDevGgyEDAjPYVm8KS0w3KAKGpkIPJfPuQWmpRxgI_QQ";
+const dummyTokenExpiry = new Date(1615667806000);
+const dummyUserToken =
+  "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0YWtvbyIsInJvbGUiOiJVU0VSIiwiZXhwIjoxNjE1NjY3ODQzfQ.ZREE9nlhA0706bxdWvSjne2K4pivSJDUN_1SY5YNhh4SR-6RPXXLEpqVMHnfT9tZxLiJZ8YCdRvgA6wxhX-dSw";
+const dummyAdminToken = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJub2dnIiwicm9sZSI6IkFETUlOIiwiZXhwIjoxNjE1NjY3ODY2fQ.rxXWY5gwPtt0wu_1Qcaedp-rNZnCWP95aLq9LHGF7I8InO3N_2CV25Jhf1o84wc7slgqyMV9lFROEiVFUvDMAg";
 
 jest.mock("js-cookie");
 jest.spyOn(Cookies, "get");
@@ -19,9 +20,9 @@ describe("AuthenticationUtil", () => {
   });
 
   describe("saveToken", () => {
-    it("should save the token to local storage", () => {
-      AuthenticationUtil.saveToken(dummyToken);
-      expect(Cookies.set).toHaveBeenCalledWith("authToken", dummyToken, {
+    it("should save the token in a cookie", () => {
+      AuthenticationUtil.saveToken(dummySuperuserToken);
+      expect(Cookies.set).toHaveBeenCalledWith("authToken", dummySuperuserToken, {
         expires: dummyTokenExpiry,
         SameSite: "Strict"
       });
@@ -31,9 +32,9 @@ describe("AuthenticationUtil", () => {
   describe("getAuthorizationHeader", () => {
     it("should get the correct authorization header", () => {
       const expectedHeader = {
-        headers: { Authorization: `${dummyToken}` }
+        headers: { Authorization: `${dummySuperuserToken}` }
       };
-      Cookies.get.mockReturnValue(dummyToken);
+      Cookies.get.mockReturnValue(dummySuperuserToken);
 
       const result = AuthenticationUtil.getAuthorizationHeader();
 
@@ -44,7 +45,7 @@ describe("AuthenticationUtil", () => {
 
   describe("isAuthenticated", () => {
     it("should return true if auth token is defined", () => {
-      Cookies.get.mockReturnValue(dummyToken);
+      Cookies.get.mockReturnValue(dummySuperuserToken);
       const authenticated = AuthenticationUtil.isAuthenticated();
 
       expect(Cookies.get).toHaveBeenCalledWith("authToken");
@@ -61,16 +62,24 @@ describe("AuthenticationUtil", () => {
   });
 
   describe("isAdmin", () => {
-    it("should return true if jwt token has role admin", () => {
-      Cookies.get.mockReturnValue(dummyToken);
+    it("should return true if jwt token has role SUPERUSER", () => {
+      Cookies.get.mockReturnValue(dummySuperuserToken);
       const admin = AuthenticationUtil.isAdmin();
 
       expect(Cookies.get).toHaveBeenCalledWith("authToken");
       expect(admin).toEqual(true);
     });
 
-    it("should return false if jwt token does not have role admin", () => {
-      Cookies.get.mockReturnValue(dummyTokenNotAdmin);
+    it("should return true if jwt token has role ADMIN", () => {
+        Cookies.get.mockReturnValue(dummyAdminToken);
+        const admin = AuthenticationUtil.isAdmin();
+  
+        expect(Cookies.get).toHaveBeenCalledWith("authToken");
+        expect(admin).toEqual(true);
+      });
+
+    it("should return false if jwt token has role USER", () => {
+      Cookies.get.mockReturnValue(dummyUserToken);
       const admin = AuthenticationUtil.isAdmin();
 
       expect(Cookies.get).toHaveBeenCalledWith("authToken");

--- a/frontend/src/api/tests/LogApi.test.js
+++ b/frontend/src/api/tests/LogApi.test.js
@@ -4,11 +4,13 @@ import Adapter from "enzyme-adapter-react-16";
 import { afterEach, describe, expect, it, jest } from "@jest/globals";
 import * as LogApi from "../LogApi";
 import * as SampleData from "../SampleData";
-import * as authenticationUtil from "../AuthenticationUtil";
+import * as AuthenticationUtil from "../AuthenticationUtil";
 
 Enzyme.configure({ adapter: new Adapter() });
 
 jest.mock("axios");
+jest.mock("../AuthenticationUtil");
+jest.spyOn(AuthenticationUtil, "getAuthorizationHeader");
 
 const authorizationHeader = {
   headers: {
@@ -51,7 +53,16 @@ SampleData.getAllLogs((result) => {
   sampleLogs = result;
 });
 
+const authorizationHeader = {
+    headers: {
+      Authorization: "Bearer the_token"
+    }
+  };
+
 describe("Log Api", () => {
+  beforeEach(() => {
+    AuthenticationUtil.getAuthorizationHeader.mockReturnValue(authorizationHeader);
+  })
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -59,7 +70,7 @@ describe("Log Api", () => {
   describe("getDeviceLogs", () => {
     it("should call axios.get and return device logs from a device/serial number", async () => {
       axios.get.mockResolvedValue({ data: mockLogs });
-      authenticationUtil.getAuthorizationHeader = jest
+      AuthenticationUtil.getAuthorizationHeader = jest
         .fn()
         .mockReturnValue(authorizationHeader);
       const result = await LogApi.getDeviceLogs(123);
@@ -80,7 +91,7 @@ describe("Log Api", () => {
   describe("getAllLogs", () => {
     it("should call axios.get and return an array of streams", async () => {
       axios.get.mockResolvedValue({ data: mockLogs });
-      authenticationUtil.getAuthorizationHeader = jest
+      AuthenticationUtil.getAuthorizationHeader = jest
         .fn()
         .mockReturnValue(authorizationHeader);
       const result = await LogApi.getAllLogs();

--- a/frontend/src/api/tests/LogApi.test.js
+++ b/frontend/src/api/tests/LogApi.test.js
@@ -54,15 +54,17 @@ SampleData.getAllLogs((result) => {
 });
 
 const authorizationHeader = {
-    headers: {
-      Authorization: "Bearer the_token"
-    }
-  };
+  headers: {
+    Authorization: "Bearer the_token"
+  }
+};
 
 describe("Log Api", () => {
   beforeEach(() => {
-    AuthenticationUtil.getAuthorizationHeader.mockReturnValue(authorizationHeader);
-  })
+    AuthenticationUtil.getAuthorizationHeader.mockReturnValue(
+      authorizationHeader
+    );
+  });
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/frontend/src/api/tests/LogApi.test.js
+++ b/frontend/src/api/tests/LogApi.test.js
@@ -12,12 +12,6 @@ jest.mock("axios");
 jest.mock("../AuthenticationUtil");
 jest.spyOn(AuthenticationUtil, "getAuthorizationHeader");
 
-const authorizationHeader = {
-  headers: {
-    Authorization: "Bearer the_token"
-  }
-};
-
 const mockLogs = [
   {
     id: 1,

--- a/frontend/src/app/AdminProtectedRoute.jsx
+++ b/frontend/src/app/AdminProtectedRoute.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Redirect, Route } from "react-router-dom";
 import ProtectedRoute from "./ProtectedRoute";
-import { isAdmin } from "../api/AuthenticationApi";
+import { isAdmin } from "../api/AuthenticationUtil";
 
 export default class AdminProtectedRoute extends React.Component {
   constructor(props) {

--- a/frontend/src/app/ProtectedRoute.jsx
+++ b/frontend/src/app/ProtectedRoute.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Redirect, Route } from "react-router-dom";
 
-import { isAuthenticated } from "../api/AuthenticationApi";
+import { isAuthenticated } from "../api/AuthenticationUtil";
 
 export default class ProtectedRoute extends React.Component {
   constructor(props) {

--- a/frontend/src/app/__tests__/AdminProtectedRoute.test.jsx
+++ b/frontend/src/app/__tests__/AdminProtectedRoute.test.jsx
@@ -5,11 +5,11 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { Route } from "react-router-dom";
 import AdminProtectedRoute from "../AdminProtectedRoute";
 
-import * as AuthenticationApi from "../../api/AuthenticationApi";
+import * as AuthenticationUtil from "../../api/AuthenticationUtil";
 
 Enzyme.configure({ adapter: new Adapter() });
-jest.mock("../../api/AuthenticationApi");
-jest.spyOn(AuthenticationApi, "isAdmin");
+jest.mock("../../api/AuthenticationUtil");
+jest.spyOn(AuthenticationUtil, "isAdmin");
 
 describe("<AdminProtectedRoute/> class component", () => {
   let wrapper;
@@ -33,7 +33,7 @@ describe("<AdminProtectedRoute/> class component", () => {
   describe("component() function", () => {
     describe("when AuthApi.isAdmin() returns true", () => {
       beforeEach(() => {
-        AuthenticationApi.isAdmin.mockReturnValue(true);
+        AuthenticationUtil.isAdmin.mockReturnValue(true);
       });
       it("should return a <ProtectedRoute> with expected props", () => {
         wrapper = Enzyme.shallow(
@@ -47,7 +47,7 @@ describe("<AdminProtectedRoute/> class component", () => {
     });
     describe("when AuthApi.isAdmin() returns false", () => {
       beforeEach(() => {
-        AuthenticationApi.isAdmin.mockReturnValue(false);
+        AuthenticationUtil.isAdmin.mockReturnValue(false);
       });
       it("should return a <Redirect/> component with pathname /Invalid", () => {
         wrapper = Enzyme.shallow(

--- a/frontend/src/app/__tests__/ProtectedRoute.test.jsx
+++ b/frontend/src/app/__tests__/ProtectedRoute.test.jsx
@@ -5,11 +5,11 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { Route } from "react-router-dom";
 import ProtectedRoute from "../ProtectedRoute";
 
-import * as AuthenticationApi from "../../api/AuthenticationApi";
+import * as AuthenticationUtil from "../../api/AuthenticationUtil";
 
 Enzyme.configure({ adapter: new Adapter() });
-jest.mock("../../api/AuthenticationApi");
-jest.spyOn(AuthenticationApi, "isAuthenticated");
+jest.mock("../../api/AuthenticationUtil");
+jest.spyOn(AuthenticationUtil, "isAuthenticated");
 
 describe("<ProtectedRoute/> class component", () => {
   let wrapper;
@@ -34,7 +34,7 @@ describe("<ProtectedRoute/> class component", () => {
   describe("component() function", () => {
     describe("when AuthApi.isAuthenticated() returns true", () => {
       beforeEach(() => {
-        AuthenticationApi.isAuthenticated.mockReturnValue(true);
+        AuthenticationUtil.isAuthenticated.mockReturnValue(true);
       });
       describe("if prop authenticationRequired is true", () => {
         it("should call the passed render function", () => {
@@ -63,7 +63,7 @@ describe("<ProtectedRoute/> class component", () => {
     });
     describe("when AuthApi.isAuthenticated() returns false", () => {
       beforeEach(() => {
-        AuthenticationApi.isAuthenticated.mockReturnValue(false);
+        AuthenticationUtil.isAuthenticated.mockReturnValue(false);
       });
       describe("if prop authenticationRequired is true", () => {
         it("should return a <Redirect/> component with expected props", () => {

--- a/frontend/src/general/HeaderBar.jsx
+++ b/frontend/src/general/HeaderBar.jsx
@@ -15,13 +15,13 @@ class HeaderBar extends React.Component {
         marginRight: theme.spacing(2)
       }
     }));
+    this.handleLogout = this.handleLogout.bind(this);
   }
 
   handleLogout() {
     const { history } = this.props;
     logOut();
     history.push("/Login");
-    history.go(0);
   }
 
   render() {
@@ -46,7 +46,7 @@ class HeaderBar extends React.Component {
               id="acctBtn"
               color="inherit"
               disabled={!isAuthenticated()}
-              onClick={logOut}
+              onClick={this.handleLogout}
             >
               <AccountCircle />
             </IconButton>

--- a/frontend/src/general/HeaderBar.jsx
+++ b/frontend/src/general/HeaderBar.jsx
@@ -4,7 +4,8 @@ import { withRouter, NavLink } from "react-router-dom";
 import { AppBar, IconButton, makeStyles, Toolbar } from "@material-ui/core";
 import { AccountCircle, Home } from "@material-ui/icons/";
 
-import { isAuthenticated, handleLogout } from "../api/AuthenticationApi";
+import { logOut } from "../api/AuthenticationApi";
+import { isAuthenticated } from "../api/AuthenticationUtil";
 
 class HeaderBar extends React.Component {
   constructor(props) {
@@ -18,7 +19,7 @@ class HeaderBar extends React.Component {
 
   handleLogout() {
     const { history } = this.props;
-    handleLogout();
+    logOut();
     history.push("/Login");
     history.go(0);
   }
@@ -45,7 +46,7 @@ class HeaderBar extends React.Component {
               id="acctBtn"
               color="inherit"
               disabled={!isAuthenticated()}
-              onClick={handleLogout}
+              onClick={logOut}
             >
               <AccountCircle />
             </IconButton>

--- a/frontend/src/general/PathNotFoundPage.jsx
+++ b/frontend/src/general/PathNotFoundPage.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import DashboardButton from "./dashboard/DashboardButton";
 import DashboardCard from "./dashboard/DashboardCard";
 import Page from "./Page";
-import { isAuthenticated } from "../api/AuthenticationApi";
+import { isAuthenticated } from "../api/AuthenticationUtil";
 
 export default function PathNotFoundPage() {
   return (

--- a/frontend/src/general/__tests__/HeaderBar.test.jsx
+++ b/frontend/src/general/__tests__/HeaderBar.test.jsx
@@ -78,8 +78,5 @@ describe("<HeaderBar/> functional Component", () => {
     it("calls history.push() with expected value", () => {
       expect(mockPush).toBeCalledWith("/Login");
     });
-    it("calls history.go() with expected value", () => {
-      expect(mockGo).toBeCalledWith(0);
-    });
   });
 });

--- a/frontend/src/general/__tests__/HeaderBar.test.jsx
+++ b/frontend/src/general/__tests__/HeaderBar.test.jsx
@@ -69,11 +69,11 @@ describe("<HeaderBar/> functional Component", () => {
   });
   describe("handleLogout() function", () => {
     beforeEach(() => {
-      jest.spyOn(AuthApi, "handleLogout");
+      jest.spyOn(AuthApi, "logOut");
       wrapper.instance().handleLogout();
     });
-    it("calls AuthApi.handleLogout() function", () => {
-      expect(AuthApi.handleLogout).toBeCalled();
+    it("calls AuthApi.logOut() function", () => {
+      expect(AuthApi.logOut).toBeCalled();
     });
     it("calls history.push() with expected value", () => {
       expect(mockPush).toBeCalledWith("/Login");

--- a/frontend/src/general/__tests__/PathNotFoundPage.test.jsx
+++ b/frontend/src/general/__tests__/PathNotFoundPage.test.jsx
@@ -19,9 +19,11 @@ describe("<PathNotFoundPage/> functional Component", () => {
   describe("returns a component that", () => {
     describe("when AuthenticationUtil.isAuthenticated() returns true", () => {
       beforeEach(() => {
-        jest.spyOn(AuthenticationUtil, "isAuthenticated").mockImplementation(() => {
-          return true;
-        });
+        jest
+          .spyOn(AuthenticationUtil, "isAuthenticated")
+          .mockImplementation(() => {
+            return true;
+          });
         wrapper = Enzyme.shallow(<PathNotFoundPage />);
       });
       it("Contains 1 <Page/> component with correct props", () => {
@@ -75,9 +77,11 @@ describe("<PathNotFoundPage/> functional Component", () => {
     });
     describe("when AuthenticationUtil.isAuthenticated() returns false", () => {
       beforeEach(() => {
-        jest.spyOn(AuthenticationUtil, "isAuthenticated").mockImplementation(() => {
-          return false;
-        });
+        jest
+          .spyOn(AuthenticationUtil, "isAuthenticated")
+          .mockImplementation(() => {
+            return false;
+          });
         wrapper = Enzyme.shallow(<PathNotFoundPage />);
       });
       it("Contains 1 <Page/> component with correct props", () => {

--- a/frontend/src/general/__tests__/PathNotFoundPage.test.jsx
+++ b/frontend/src/general/__tests__/PathNotFoundPage.test.jsx
@@ -7,7 +7,7 @@ import { Grid } from "@material-ui/core";
 import PathNotFoundPage from "../PathNotFoundPage";
 import Page from "../Page";
 
-import * as AuthApi from "../../api/AuthenticationApi";
+import * as AuthenticationUtil from "../../api/AuthenticationUtil";
 import DashboardButton from "../dashboard/DashboardButton";
 import DashboardCard from "../dashboard/DashboardCard";
 
@@ -17,9 +17,9 @@ describe("<PathNotFoundPage/> functional Component", () => {
   let wrapper;
 
   describe("returns a component that", () => {
-    describe("when AuthApi.isAuthenticated() returns true", () => {
+    describe("when AuthenticationUtil.isAuthenticated() returns true", () => {
       beforeEach(() => {
-        jest.spyOn(AuthApi, "isAuthenticated").mockImplementation(() => {
+        jest.spyOn(AuthenticationUtil, "isAuthenticated").mockImplementation(() => {
           return true;
         });
         wrapper = Enzyme.shallow(<PathNotFoundPage />);
@@ -73,9 +73,9 @@ describe("<PathNotFoundPage/> functional Component", () => {
         expect(props.children).toBe(expectedText);
       });
     });
-    describe("when AuthApi.isAuthenticated() returns false", () => {
+    describe("when AuthenticationUtil.isAuthenticated() returns false", () => {
       beforeEach(() => {
-        jest.spyOn(AuthApi, "isAuthenticated").mockImplementation(() => {
+        jest.spyOn(AuthenticationUtil, "isAuthenticated").mockImplementation(() => {
           return false;
         });
         wrapper = Enzyme.shallow(<PathNotFoundPage />);

--- a/frontend/src/homepage/HomePageContents.jsx
+++ b/frontend/src/homepage/HomePageContents.jsx
@@ -7,7 +7,7 @@ import ActivityLogCard from "./ActivityLogCard";
 import DevicesCard from "./DevicesCard";
 import AdminPanelCard from "./AdminPanelCard";
 
-import { isAdmin } from "../api/AuthenticationApi";
+import { isAdmin } from "../api/AuthenticationUtil";
 
 export default function HomePageContents() {
   return (

--- a/frontend/src/homepage/__tests__/HomePageContents.test.jsx
+++ b/frontend/src/homepage/__tests__/HomePageContents.test.jsx
@@ -18,16 +18,16 @@ import ActiveStreamCard from "../ActiveStreamCard";
 import ActivityLogCard from "../ActivityLogCard";
 import DevicesCard from "../DevicesCard";
 
-import * as AuthenticationApi from "../../api/AuthenticationApi";
+import * as AuthenticationUtil from "../../api/AuthenticationUtil";
 
 Enzyme.configure({ adapter: new Adapter() });
-jest.mock("../../api/AuthenticationApi");
+jest.mock("../../api/AuthenticationUtil");
 describe("<HomePage/> functional component", () => {
   let wrapper;
 
-  describe("when AuthenticationApi.isAdmin() returns true", () => {
+  describe("when AuthenticationUtil.isAdmin() returns true", () => {
     beforeEach(() => {
-      AuthenticationApi.isAdmin.mockImplementation(() => true);
+      AuthenticationUtil.isAdmin.mockImplementation(() => true);
       wrapper = Enzyme.shallow(<HomePageContents />);
     });
     afterEach(() => {
@@ -109,9 +109,9 @@ describe("<HomePage/> functional component", () => {
       expect(wrapper.find(AdminPanelCard)).toHaveLength(1);
     });
   });
-  describe("when AuthenticationApi.isAdmin() returns false", () => {
+  describe("when AuthenticationUtil.isAdmin() returns false", () => {
     beforeEach(() => {
-      AuthenticationApi.isAdmin.mockImplementation(() => false);
+      AuthenticationUtil.isAdmin.mockImplementation(() => false);
       wrapper = Enzyme.shallow(<HomePageContents />);
     });
 

--- a/frontend/src/login/LoginPageContents.jsx
+++ b/frontend/src/login/LoginPageContents.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import LoginFailedDialog from "./LoginFailedDialog";
 import LoginConsole from "./LoginConsole";
-import { handleLogin, logIn } from "../api/AuthenticationApi";
+import { logIn } from "../api/AuthenticationApi";
 
 export default class LoginPageContents extends React.Component {
   constructor(props) {
@@ -19,14 +19,16 @@ export default class LoginPageContents extends React.Component {
 
   handleSubmit(username, password) {
     const { history } = this.props;
-    handleLogin();
-    logIn({ username, password }).catch((error) => {
-      this.setState({
-        dialogOpen: true,
-        dialogMessage: error.message
+    logIn({ username, password })
+      .then(() => {
+        history.push("/Home");
+      })
+      .catch((error) => {
+        this.setState({
+          dialogOpen: true,
+          dialogMessage: error.message
+        });
       });
-    });
-    history.push("/Home");
   }
 
   setDialogOpen(open) {

--- a/frontend/src/login/LoginPageContents.jsx
+++ b/frontend/src/login/LoginPageContents.jsx
@@ -27,7 +27,6 @@ export default class LoginPageContents extends React.Component {
       });
     });
     history.push("/Home");
-    history.go(0);
   }
 
   setDialogOpen(open) {

--- a/frontend/src/login/__tests__/LoginPageContent.test.jsx
+++ b/frontend/src/login/__tests__/LoginPageContent.test.jsx
@@ -80,8 +80,9 @@ describe("<LoginPageContents/> class component", () => {
         });
 
         wrapper.instance().handleSubmit(someUsername, somePassword);
-
-        await Promise.resolve(setImmediate);
+        
+        const flushPromises = () => new Promise(setImmediate);
+        await flushPromises();
 
         expect(wrapper.state()).toEqual({
           dialogOpen: true,

--- a/frontend/src/login/__tests__/LoginPageContent.test.jsx
+++ b/frontend/src/login/__tests__/LoginPageContent.test.jsx
@@ -80,7 +80,7 @@ describe("<LoginPageContents/> class component", () => {
         });
 
         wrapper.instance().handleSubmit(someUsername, somePassword);
-        
+
         const flushPromises = () => new Promise(setImmediate);
         await flushPromises();
 

--- a/frontend/src/login/__tests__/LoginPageContent.test.jsx
+++ b/frontend/src/login/__tests__/LoginPageContent.test.jsx
@@ -58,10 +58,12 @@ describe("<LoginPageContents/> class component", () => {
     const someUsername = "username";
     const somePassword = "password";
     describe("when logIn resolves", () => {
-      it("Calls login and redirects to home", () => {
+      it("Calls login and redirects to home", async () => {
         AuthenticationApi.logIn.mockResolvedValue();
 
         wrapper.instance().handleSubmit(someUsername, somePassword);
+
+        await new Promise(setImmediate);
 
         expect(AuthenticationApi.logIn).toHaveBeenCalledWith({
           username: someUsername,

--- a/frontend/src/login/__tests__/LoginPageContent.test.jsx
+++ b/frontend/src/login/__tests__/LoginPageContent.test.jsx
@@ -71,7 +71,6 @@ describe("<LoginPageContents/> class component", () => {
           password: somePassword
         });
         expect(mockHistory.push).toHaveBeenCalledWith("/Home");
-        expect(mockHistory.go).toHaveBeenCalledWith(0);
       });
     });
     describe("when logIn rejects", () => {

--- a/frontend/src/login/__tests__/LoginPageContent.test.jsx
+++ b/frontend/src/login/__tests__/LoginPageContent.test.jsx
@@ -11,7 +11,6 @@ import * as AuthenticationApi from "../../api/AuthenticationApi";
 Enzyme.configure({ adapter: new Adapter() });
 jest.mock("../../api/AuthenticationApi");
 jest.spyOn(AuthenticationApi, "logIn");
-jest.spyOn(AuthenticationApi, "handleLogin");
 
 describe("<LoginPageContents/> class component", () => {
   let wrapper;
@@ -60,12 +59,10 @@ describe("<LoginPageContents/> class component", () => {
     const somePassword = "password";
     describe("when logIn resolves", () => {
       it("Calls login and redirects to home", () => {
-        AuthenticationApi.handleLogin.mockReturnValue();
         AuthenticationApi.logIn.mockResolvedValue();
 
         wrapper.instance().handleSubmit(someUsername, somePassword);
 
-        expect(AuthenticationApi.handleLogin).toHaveBeenCalled();
         expect(AuthenticationApi.logIn).toHaveBeenCalledWith({
           username: someUsername,
           password: somePassword
@@ -76,7 +73,6 @@ describe("<LoginPageContents/> class component", () => {
     describe("when logIn rejects", () => {
       it("Changes state to dialog open", async () => {
         const someErrorMessage = "errorMessage";
-        AuthenticationApi.handleLogin.mockReturnValue();
         AuthenticationApi.logIn.mockRejectedValue({
           message: someErrorMessage
         });

--- a/frontend/src/streamlist/DeleteStreamDialog.jsx
+++ b/frontend/src/streamlist/DeleteStreamDialog.jsx
@@ -9,6 +9,7 @@ export default class DeleteStreamDialog extends React.Component {
     super(props);
 
     this.dialogElement = React.createRef();
+    this.afterDelete = this.afterDelete.bind(this);
     this.confirmDelete = this.confirmDelete.bind(this);
     this.openDialog = this.openDialog.bind(this);
   }
@@ -22,7 +23,7 @@ export default class DeleteStreamDialog extends React.Component {
 
   confirmDelete() {
     const { deleteId } = this.props;
-    deleteStream(deleteId).then(this.afterDelete.bind(this));
+    deleteStream(deleteId).then(this.afterDelete);
   }
 
   // used by Summoner to summon

--- a/frontend/src/streamlist/DeleteStreamDialog.jsx
+++ b/frontend/src/streamlist/DeleteStreamDialog.jsx
@@ -22,7 +22,7 @@ export default class DeleteStreamDialog extends React.Component {
 
   confirmDelete() {
     const { deleteId } = this.props;
-    deleteStream(deleteId).finally(this.afterDelete());
+    deleteStream(deleteId).then(this.afterDelete.bind(this));
   }
 
   // used by Summoner to summon

--- a/src/main/java/org/beanpod/switchboard/config/WebSecurityConfig.java
+++ b/src/main/java/org/beanpod/switchboard/config/WebSecurityConfig.java
@@ -80,7 +80,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
   @Bean
   CorsConfigurationSource corsConfigurationSource() {
     final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-    source.registerCorsConfiguration("/**", new CorsConfiguration().applyPermitDefaultValues());
+    final CorsConfiguration corsConfiguration = new CorsConfiguration().applyPermitDefaultValues();
+    corsConfiguration.addAllowedMethod("DELETE");
+    source.registerCorsConfiguration("/**", corsConfiguration);
     return source;
   }
 


### PR DESCRIPTION
# General info
Integrate the protected routes code with frontend auth.

**Issue number**: Related to #330 

## Changelog

- Store JWT in cookies instead of local storage (because cookies expire automatically, while local storage we would have to manually write code to handle expiry)
- Add code to parse JWT in order to check expiry and user type

- Fixed an issue where redirecting from login to home refreshes for no reason
- Fixed an issue where logging out does not redirect to login
- Fixed an issue where CORS requests were disabled for DELETE method

- Moved some functions from AuthenticationApi to AuthenticationUtil
- Removed some functions from AuthenticationApi that are no longer needed
- Refactoring to account for moved and renamed functions