### PR TITLE
[#380] Fix Device Details Path Bug

### DIFF
--- a/frontend/src/devicelist/ActionMenu.jsx
+++ b/frontend/src/devicelist/ActionMenu.jsx
@@ -58,7 +58,7 @@ export default class ActionMenu extends React.Component {
           <MenuItem onClick={this.handleClose}>
             <NavLink
               to={{
-                pathname: `/Devices/Details/${device.name}`,
+                pathname: `/Devices/Details/${device.serialNumber}`,
                 state: { device }
               }}
               className="hideLinkStyle"

--- a/frontend/src/devicelist/DevicesTable.jsx
+++ b/frontend/src/devicelist/DevicesTable.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { NavLink } from "react-router-dom";
 import { Box, TableContainer, Typography } from "@material-ui/core";
 import PropTypes from "prop-types";
 
@@ -41,7 +40,7 @@ function getColumnInfo() {
   return [
     {
       title: "Name",
-      field: "name",
+      field: "name"
     },
     {
       title: "Serial Number",

--- a/frontend/src/devicelist/DevicesTable.jsx
+++ b/frontend/src/devicelist/DevicesTable.jsx
@@ -37,25 +37,11 @@ function getComponents() {
   };
 }
 
-function buildNavlink(deviceInfo) {
-  return (
-    <NavLink
-      to={{
-        pathname: `/Devices/Details/${deviceInfo.serialNumber}`,
-        state: { device: deviceInfo }
-      }}
-    >
-      {deviceInfo.name}
-    </NavLink>
-  );
-}
-
 function getColumnInfo() {
   return [
     {
       title: "Name",
       field: "name",
-      render: (rowData) => buildNavlink(rowData)
     },
     {
       title: "Serial Number",


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: closes #380

**Task description**: 
 - Updated navlink for `View Details` button 
 - Removed redundant link to device details that was on the device name
 
<!-- What changed? What does this do? Provide screenshots if necessary--> 
| Original   | Updated|
|:---------------:|:---------------:|
| (from `View Details`) ![image](https://user-images.githubusercontent.com/22307286/111206169-6c1b7d80-859e-11eb-8c07-8ddb6f7ebde9.png) | (from `View Details`) ![image](https://user-images.githubusercontent.com/22307286/111206090-54dc9000-859e-11eb-93cf-931dd78ce2ee.png) |
| ![image](https://user-images.githubusercontent.com/22307286/111206316-9836fe80-859e-11eb-8adc-2e70ffe08af8.png) | ![image](https://user-images.githubusercontent.com/22307286/111205847-0fb85e00-859e-11eb-9148-139b28894a55.png) |

# Testing

**Test coverage**:
- unchanged

# Additional notes
- tackled the monumental task of getting rid of navlink in name. you can thank me for my service in your review :heart: