### PR TITLE
Refactor Tests to use toBe(true) instead of toBeTruthy

### DIFF
--- a/frontend/src/app/__tests__/AdminProtectedRoute.test.jsx
+++ b/frontend/src/app/__tests__/AdminProtectedRoute.test.jsx
@@ -25,7 +25,7 @@ describe("<AdminProtectedRoute/> class component", () => {
       const routeComponent = wrapper.find(Route);
       expect(routeComponent).toHaveLength(1);
       const props = routeComponent.first().props();
-      expect(props.exact).toBeTruthy();
+      expect(props.exact).toBe(true);
       expect(props.path).toEqual(dummyPath);
       expect(props.render).toBeInstanceOf(Function);
     });

--- a/frontend/src/app/__tests__/AppRouter.test.jsx
+++ b/frontend/src/app/__tests__/AppRouter.test.jsx
@@ -38,7 +38,7 @@ describe("<AppRouter/> functional component", () => {
 
     const homeRoute = protectedRoutes.at(1);
     expect(homeRoute.props().path).toEqual("/Home");
-    expect(homeRoute.props().authenticationRequired).toBeTruthy();
+    expect(homeRoute.props().authenticationRequired).toBe(true);
     const homePage = homeRoute.props().render();
     expect(homePage.type).toEqual(HomePage);
 
@@ -46,31 +46,31 @@ describe("<AppRouter/> functional component", () => {
     expect(deviceDetailsRoute.props().path).toEqual(
       "/Devices/Details/:serialNumber"
     );
-    expect(deviceDetailsRoute.props().authenticationRequired).toBeTruthy();
+    expect(deviceDetailsRoute.props().authenticationRequired).toBe(true);
     const deviceDetailsPage = deviceDetailsRoute.props().render(dummyLocation);
     expect(deviceDetailsPage.type).toEqual(DeviceDetailsPage);
 
     const deviceListRoute = protectedRoutes.at(3);
     expect(deviceListRoute.props().path).toEqual("/Devices");
-    expect(deviceListRoute.props().authenticationRequired).toBeTruthy();
+    expect(deviceListRoute.props().authenticationRequired).toBe(true);
     const deviceListPage = deviceListRoute.props().render();
     expect(deviceListPage.type).toEqual(DeviceListPage);
 
     const createStreamRoute = protectedRoutes.at(4);
     expect(createStreamRoute.props().path).toEqual("/Streams/New");
-    expect(createStreamRoute.props().authenticationRequired).toBeTruthy();
+    expect(createStreamRoute.props().authenticationRequired).toBe(true);
     const createStreamPage = createStreamRoute.props().render();
     expect(createStreamPage.type).toEqual(CreateStreamPage);
 
     const streamListRoute = protectedRoutes.at(5);
     expect(streamListRoute.props().path).toEqual("/Streams");
-    expect(streamListRoute.props().authenticationRequired).toBeTruthy();
+    expect(streamListRoute.props().authenticationRequired).toBe(true);
     const streamListPage = streamListRoute.props().render();
     expect(streamListPage.type).toEqual(StreamListPage);
 
     const logListRoute = protectedRoutes.at(6);
     expect(logListRoute.props().path).toEqual("/Logs");
-    expect(logListRoute.props().authenticationRequired).toBeTruthy();
+    expect(logListRoute.props().authenticationRequired).toBe(true);
     const logListPage = logListRoute.props().render();
     expect(logListPage.type).toEqual(LogListPage);
 

--- a/frontend/src/app/__tests__/ProtectedRoute.test.jsx
+++ b/frontend/src/app/__tests__/ProtectedRoute.test.jsx
@@ -26,7 +26,7 @@ describe("<ProtectedRoute/> class component", () => {
       const routeComponent = wrapper.find(Route);
       expect(routeComponent).toHaveLength(1);
       const props = routeComponent.first().props();
-      expect(props.exact).toBeTruthy();
+      expect(props.exact).toBe(true);
       expect(props.path).toEqual(dummyPath);
       expect(props.render).toBeInstanceOf(Function);
     });


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: n/a

**Task description**: 
 - Updated tests using `toBeTruthy` to use `toBe(true)` instead since the latter is better practice & the former isn't necessary for the tests to work

# Testing

**Test coverage**:
- unchanged

# Additional notes
- mwah 😚 
