### PR TITLE
[#408] Fixed issues causing Rename Device to fail

### DIFF
--- a/frontend/src/api/DeviceApi.js
+++ b/frontend/src/api/DeviceApi.js
@@ -109,10 +109,12 @@ export function deleteDevice(deviceId) {
 }
 
 export async function updateDeviceName(deviceId, updatedName) {
-  return axios
-    .put(process.env.REACT_APP_DEVICE, {
+  return axios.put(
+    process.env.REACT_APP_DEVICE,
+    {
       serialNumber: deviceId,
       displayName: updatedName
-    })
-    .catch(() => {});
+    },
+    getAuthorizationHeader()
+  );
 }

--- a/frontend/src/api/tests/DeviceApi.test.js
+++ b/frontend/src/api/tests/DeviceApi.test.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { jest } from "@jest/globals";
+import { describe, expect, jest } from "@jest/globals";
 import * as DeviceApi from "../DeviceApi";
 import * as DeviceFixture from "./DeviceFixture";
 import * as authenticationUtil from "../AuthenticationUtil";
@@ -70,6 +70,27 @@ describe("DeviceApi", () => {
           done(error);
         }
       });
+    });
+  });
+
+  describe("updateDeviceName", () => {
+    it("Should call axios with the device serial number, new name, and authorization headers", async () => {
+      axios.put.mockResolvedValue();
+
+      authenticationUtil.getAuthorizationHeader = jest
+        .fn()
+        .mockReturnValue(authorizationHeader);
+
+      const dummySerial = "someDeviceId";
+      const dummyName = "someDeviceName";
+
+      await DeviceApi.updateDeviceName(dummySerial, dummyName);
+
+      expect(axios.put).toHaveBeenCalledWith(
+        process.env.REACT_APP_DEVICE,
+        { serialNumber: dummySerial, displayName: dummyName },
+        authorizationHeader
+      );
     });
   });
 });

--- a/src/main/java/org/beanpod/switchboard/config/WebSecurityConfig.java
+++ b/src/main/java/org/beanpod/switchboard/config/WebSecurityConfig.java
@@ -82,6 +82,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     final CorsConfiguration corsConfiguration = new CorsConfiguration().applyPermitDefaultValues();
     corsConfiguration.addAllowedMethod("DELETE");
+    corsConfiguration.addAllowedMethod("PUT");
     source.registerCorsConfiguration("/**", corsConfiguration);
     return source;
   }


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: #408 

**Task description**: 

 - Enabled CORS for PUT requests
 - Added authorization header to update device name call
 - Added missing test for DeviceApi.updateDeviceName

# Additional notes

Fix necessary for us to pass the acceptance criteria for rename device