### PR TITLE
Set Up Models and Api for Stream Statistics

### DIFF
--- a/frontend/src/api/StreamApi.js
+++ b/frontend/src/api/StreamApi.js
@@ -1,5 +1,8 @@
 import axios from "axios";
-import { convertToDataObject } from "../model/ConvertDataFormat";
+import {
+  convertDeviceToDataObject,
+  convertStatsToDataObject
+} from "../model/ConvertDataFormat";
 import StreamInfo from "../model/StreamInfo";
 import { getAuthorizationHeader } from "./AuthenticationUtil";
 
@@ -13,8 +16,8 @@ export async function getStream(streamId) {
       const stream = response.data;
       return new StreamInfo(
         stream.id,
-        convertToDataObject(stream.outputChannel.encoder),
-        convertToDataObject(stream.inputChannel.decoder),
+        convertDeviceToDataObject(stream.outputChannel.encoder),
+        convertDeviceToDataObject(stream.inputChannel.decoder),
         stream.outputChannel.channel.port,
         stream.inputChannel.channel.port
       );
@@ -49,4 +52,16 @@ export async function createStream(selectedReceiverID, selectedSenderID) {
     },
     getAuthorizationHeader()
   );
+}
+
+export async function getStreamStatistics(streamId) {
+  return axios
+    .get(
+      `${process.env.REACT_APP_STREAM}/statistics/${streamId}`,
+      getAuthorizationHeader()
+    )
+    .then((response) => {
+      const stats = response.data;
+      return convertStatsToDataObject(stats);
+    });
 }

--- a/frontend/src/api/tests/StreamApi.test.js
+++ b/frontend/src/api/tests/StreamApi.test.js
@@ -6,7 +6,10 @@ import * as authenticationUtil from "../AuthenticationUtil";
 // import StreamApi itself
 import * as StreamApi from "../StreamApi";
 import StreamInfo from "../../model/StreamInfo";
-import { convertToDataObject } from "../../model/ConvertDataFormat";
+import {
+  convertDeviceToDataObject,
+  convertStatsToDataObject
+} from "../../model/ConvertDataFormat";
 import * as StreamFixture from "./StreamFixture";
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -17,20 +20,21 @@ jest.mock("../AuthenticationUtil");
 const {
   firstStreamResponse,
   secondStreamResponse,
-  allStreamsResponse
+  allStreamsResponse,
+  streamStatResponse
 } = StreamFixture;
 
 const expectedFirstStreamRespone = new StreamInfo(
   1,
-  convertToDataObject(firstStreamResponse.outputChannel.encoder),
-  convertToDataObject(firstStreamResponse.inputChannel.decoder),
+  convertDeviceToDataObject(firstStreamResponse.outputChannel.encoder),
+  convertDeviceToDataObject(firstStreamResponse.inputChannel.decoder),
   20001,
   20002
 );
 const expectedSecondStreamResponse = new StreamInfo(
   2,
-  convertToDataObject(secondStreamResponse.outputChannel.encoder),
-  convertToDataObject(secondStreamResponse.inputChannel.decoder),
+  convertDeviceToDataObject(secondStreamResponse.outputChannel.encoder),
+  convertDeviceToDataObject(secondStreamResponse.inputChannel.decoder),
   20000,
   20003
 );
@@ -39,6 +43,8 @@ const expectedAllStreamsResponse = [
   expectedFirstStreamRespone,
   expectedSecondStreamResponse
 ];
+
+const expectedStatsResponse = convertStatsToDataObject(streamStatResponse);
 
 const authorizationHeader = {
   headers: {
@@ -162,6 +168,26 @@ describe("Stream Api", () => {
         expectedBody,
         authorizationHeader
       );
+    });
+  });
+
+  describe("getStreamStatistics", () => {
+    it("should call axios.get and return a single stream's statistics", async () => {
+      axios.get.mockResolvedValue({ data: streamStatResponse });
+
+      authenticationUtil.getAuthorizationHeader = jest
+        .fn()
+        .mockReturnValue(authorizationHeader);
+
+      const response = await StreamApi.getStreamStatistics(1);
+
+      // check that callback was invoked with correct value
+      expect(axios.get).toHaveBeenCalledWith(
+        `http://localhost:8080/stream/statistics/1`,
+        authorizationHeader
+      );
+
+      expect(response).toEqual(expectedStatsResponse);
     });
   });
 });

--- a/frontend/src/api/tests/StreamFixture.js
+++ b/frontend/src/api/tests/StreamFixture.js
@@ -85,3 +85,38 @@ export const secondStreamResponse = {
   },
   isRendezvous: false
 };
+
+export const streamStatResponse = {
+  id: 1,
+  time: 200,
+  window: {
+    flow: 31,
+    congestion: 32,
+    flight: 33
+  },
+  link: {
+    rtt: 41,
+    bandwidth: 42,
+    maxBandwidth: 43
+  },
+  send: {
+    packets: 51,
+    packetsLost: 52,
+    packetsDropped: 53,
+    packetsRetransmitted: 54,
+    bytes: 55,
+    bytesDropped: 56,
+    mbitRate: 57
+  },
+  recv: {
+    packets: 61,
+    packetsLost: 62,
+    packetsDropped: 63,
+    packetsRetransmitted: 64,
+    packetsBelated: 65,
+    bytes: 66,
+    bytesLost: 67,
+    bytesDropped: 68,
+    mbitRate: 69
+  }
+};

--- a/frontend/src/model/ConvertDataFormat.js
+++ b/frontend/src/model/ConvertDataFormat.js
@@ -1,6 +1,11 @@
 import DeviceInfo from "./DeviceInfo";
+import StreamStatisticsInfo from "./StreamStatistics/StreamStatisticsInfo";
+import StreamStatsSendInfo from "./StreamStatistics/StreamStatsSendInfo";
+import StreamStatsReceiveInfo from "./StreamStatistics/StreamStatsReceiveInfo";
+import StreamStatsLinkInfo from "./StreamStatistics/StreamStatsLinkInfo";
+import StreamStatsWindowInfo from "./StreamStatistics/StreamStatsWindowInfo";
 
-export function convertToDataObject(databaseDevice) {
+export function convertDeviceToDataObject(databaseDevice) {
   return new DeviceInfo(
     databaseDevice.serialNumber,
     databaseDevice.lastCommunication,
@@ -10,6 +15,17 @@ export function convertToDataObject(databaseDevice) {
     databaseDevice.device.status,
     databaseDevice.inputs || databaseDevice.outputs,
     databaseDevice.inputs ? "receiver" : "sender"
+  );
+}
+
+export function convertStatsToDataObject(databaseStats) {
+  return new StreamStatisticsInfo(
+    databaseStats.id,
+    databaseStats.time,
+    new StreamStatsWindowInfo(databaseStats.window),
+    new StreamStatsLinkInfo(databaseStats.link),
+    new StreamStatsSendInfo(databaseStats.send),
+    new StreamStatsReceiveInfo(databaseStats.recv)
   );
 }
 

--- a/frontend/src/model/StreamStatistics/StreamStatisticsInfo.js
+++ b/frontend/src/model/StreamStatistics/StreamStatisticsInfo.js
@@ -1,0 +1,10 @@
+export default class StreamStatisticsInfo {
+  constructor(id, time, window, link, send, receive) {
+    this.id = id;
+    this.time = time;
+    this.window = window;
+    this.link = link;
+    this.send = send;
+    this.receive = receive;
+  }
+}

--- a/frontend/src/model/StreamStatistics/StreamStatsLinkInfo.js
+++ b/frontend/src/model/StreamStatistics/StreamStatsLinkInfo.js
@@ -1,0 +1,7 @@
+export default class StreamStatsLinkInfo {
+  constructor(link) {
+    this.rtt = link.rtt;
+    this.bandwidth = link.bandwidth;
+    this.maxBandwidth = link.maxBandwidth;
+  }
+}

--- a/frontend/src/model/StreamStatistics/StreamStatsReceiveInfo.js
+++ b/frontend/src/model/StreamStatistics/StreamStatsReceiveInfo.js
@@ -1,0 +1,13 @@
+export default class StreamStatsReceiveInfo {
+  constructor(receiving) {
+    this.packets = receiving.packets;
+    this.packetsLost = receiving.packetsLost;
+    this.packetsDropped = receiving.packetsDropped;
+    this.packetsRetransmitted = receiving.packetsRetransmitted;
+    this.packetsBelated = receiving.packetsBelated;
+    this.bytes = receiving.bytes;
+    this.bytesLost = receiving.bytesLost;
+    this.bytesDropped = receiving.bytesDropped;
+    this.mbitRate = receiving.mbitRate;
+  }
+}

--- a/frontend/src/model/StreamStatistics/StreamStatsSendInfo.js
+++ b/frontend/src/model/StreamStatistics/StreamStatsSendInfo.js
@@ -1,0 +1,11 @@
+export default class StreamStatsSendInfo {
+  constructor(sending) {
+    this.packets = sending.packets;
+    this.packetsLost = sending.packetsLost;
+    this.packetsDropped = sending.packetsDropped;
+    this.packetsRetransmitted = sending.packetsRetransmitted;
+    this.bytes = sending.bytes;
+    this.bytesDropped = sending.bytesDropped;
+    this.mbitRate = sending.mbitRate;
+  }
+}

--- a/frontend/src/model/StreamStatistics/StreamStatsWindowInfo.js
+++ b/frontend/src/model/StreamStatistics/StreamStatsWindowInfo.js
@@ -1,0 +1,7 @@
+export default class StreamStatsWindowInfo {
+  constructor(window) {
+    this.flow = window.flow;
+    this.congestion = window.congestion;
+    this.flight = window.flight;
+  }
+}

--- a/frontend/src/model/__tests__/ConvertDataFormat.test.js
+++ b/frontend/src/model/__tests__/ConvertDataFormat.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@jest/globals";
+import { describe, it, expect } from "@jest/globals";
 import {
   convertDeviceToDataObject,
   convertStatsToDataObject,
@@ -140,38 +140,42 @@ const sampleLocalStats = new StreamStatisticsInfo(
   })
 );
 
-test("convertDeviceToDataObject returns DeviceInfo object with correct data", () => {
-  const axiosSenderToLocal = JSON.stringify(
-    convertDeviceToDataObject(sampleAxiosSender)
-  );
-  const axiosReceiverToLocal = JSON.stringify(
-    convertDeviceToDataObject(sampleAxiosReceiver)
-  );
-
-  expect(axiosSenderToLocal).toStrictEqual(JSON.stringify(sampleLocalSender));
-  expect(axiosReceiverToLocal).toStrictEqual(
-    JSON.stringify(sampleLocalReceiver)
-  );
+describe("convertDeviceToDataObject function", () => {
+  it("returns a DeviceInfo object with correct data", () => {
+    const axiosSenderToLocal = JSON.stringify(
+      convertDeviceToDataObject(sampleAxiosSender)
+    );
+    const axiosReceiverToLocal = JSON.stringify(
+      convertDeviceToDataObject(sampleAxiosReceiver)
+    );
+    
+    expect(axiosSenderToLocal).toStrictEqual(JSON.stringify(sampleLocalSender));
+    expect(axiosReceiverToLocal).toStrictEqual(
+      JSON.stringify(sampleLocalReceiver)
+    );
+  });
 });
 
-test("convertToServiceObject returns information in response format with correct data", () => {
-  const localSenderToAxios = JSON.stringify(
-    convertToServiceObject(sampleLocalSender)
-  );
-  const localReceiverToAxios = JSON.stringify(
-    convertToServiceObject(sampleLocalReceiver)
-  );
-
-  expect(localSenderToAxios).toStrictEqual(JSON.stringify(sampleAxiosSender));
-  expect(localReceiverToAxios).toStrictEqual(
-    JSON.stringify(sampleAxiosReceiver)
-  );
+describe("convertToServiceObject function", () => {
+  it("returns information in response format with correct data", () => {
+    const localSenderToAxios = JSON.stringify(
+      convertToServiceObject(sampleLocalSender)
+    );
+    const localReceiverToAxios = JSON.stringify(
+      convertToServiceObject(sampleLocalReceiver)
+    );
+    
+    expect(localSenderToAxios).toStrictEqual(JSON.stringify(sampleAxiosSender));
+    expect(localReceiverToAxios).toStrictEqual(
+      JSON.stringify(sampleAxiosReceiver)
+    );
+  });
 });
 
-test("convertStatsToDataObject returns StreamStatisticsInfo object with correct data", () => {
-  const dbStatsToLocal = JSON.stringify(
-    convertStatsToDataObject(sampleDBStats)
-  );
-
-  expect(dbStatsToLocal).toStrictEqual(JSON.stringify(sampleLocalStats));
+describe("convertStatsToDataObject function", () => {
+  it("returns a StreamStatisticsInfo object with correct data", () => {
+    const dbStatsToLocal = convertStatsToDataObject(sampleDBStats);
+    
+    expect(dbStatsToLocal).toStrictEqual(sampleLocalStats);
+  });
 });

--- a/frontend/src/model/__tests__/ConvertDataFormat.test.js
+++ b/frontend/src/model/__tests__/ConvertDataFormat.test.js
@@ -1,11 +1,17 @@
 import { expect, test } from "@jest/globals";
 import {
-  convertToDataObject,
+  convertDeviceToDataObject,
+  convertStatsToDataObject,
   convertToServiceObject
 } from "../ConvertDataFormat";
 import DeviceInfo from "../DeviceInfo";
 import InChannelInfo from "../InputChannelInfo";
 import OutChannelInfo from "../OutputChannelInfo";
+import StreamStatisticsInfo from "../StreamStatistics/StreamStatisticsInfo";
+import StreamStatsSendInfo from "../StreamStatistics/StreamStatsSendInfo";
+import StreamStatsReceiveInfo from "../StreamStatistics/StreamStatsReceiveInfo";
+import StreamStatsLinkInfo from "../StreamStatistics/StreamStatsLinkInfo";
+import StreamStatsWindowInfo from "../StreamStatistics/StreamStatsWindowInfo";
 
 const sampleInputChannels = [
   new InChannelInfo(1, "test input ch 1", 500, null),
@@ -72,12 +78,74 @@ const sampleAxiosReceiver = {
   extras: undefined
 };
 
-test("convertToDataObject returns DeviceInfo object with correct data", () => {
+const sampleDBStats = {
+  id: 11,
+  time: 11,
+  window: {
+    flow: 11,
+    congestion: 11,
+    flight: 11
+  },
+  link: {
+    rtt: 11,
+    bandwidth: 11,
+    maxBandwidth: 11
+  },
+  send: {
+    packets: 11,
+    packetsLost: 11,
+    packetsDropped: 11,
+    packetsRetransmitted: 11,
+    bytes: 11,
+    bytesDropped: 11,
+    mbitRate: 11
+  },
+  recv: {
+    packets: 11,
+    packetsLost: 11,
+    packetsDropped: 11,
+    packetsRetransmitted: 11,
+    packetsBelated: 11,
+    bytes: 11,
+    bytesLost: 11,
+    bytesDropped: 11,
+    mbitRate: 11
+  }
+};
+
+const sampleLocalStats = new StreamStatisticsInfo(
+  11,
+  11,
+  new StreamStatsWindowInfo({ flow: 11, congestion: 11, flight: 11 }),
+  new StreamStatsLinkInfo({ rtt: 11, bandwidth: 11, maxBandwidth: 11 }),
+  new StreamStatsSendInfo({
+    packets: 11,
+    packetsLost: 11,
+    packetsDropped: 11,
+    packetsRetransmitted: 11,
+    bytes: 11,
+    bytesDropped: 11,
+    mbitRate: 11
+  }),
+  new StreamStatsReceiveInfo({
+    packets: 11,
+    packetsLost: 11,
+    packetsDropped: 11,
+    packetsRetransmitted: 11,
+    packetsBelated: 11,
+    bytes: 11,
+    bytesLost: 11,
+    bytesDropped: 11,
+    mbitRate: 11
+  })
+);
+
+test("convertDeviceToDataObject returns DeviceInfo object with correct data", () => {
   const axiosSenderToLocal = JSON.stringify(
-    convertToDataObject(sampleAxiosSender)
+    convertDeviceToDataObject(sampleAxiosSender)
   );
   const axiosReceiverToLocal = JSON.stringify(
-    convertToDataObject(sampleAxiosReceiver)
+    convertDeviceToDataObject(sampleAxiosReceiver)
   );
 
   expect(axiosSenderToLocal).toStrictEqual(JSON.stringify(sampleLocalSender));
@@ -98,4 +166,12 @@ test("convertToServiceObject returns information in response format with correct
   expect(localReceiverToAxios).toStrictEqual(
     JSON.stringify(sampleAxiosReceiver)
   );
+});
+
+test("convertStatsToDataObject returns StreamStatisticsInfo object with correct data", () => {
+  const dbStatsToLocal = JSON.stringify(
+    convertStatsToDataObject(sampleDBStats)
+  );
+
+  expect(dbStatsToLocal).toStrictEqual(JSON.stringify(sampleLocalStats));
 });

--- a/frontend/src/model/__tests__/ConvertDataFormat.test.js
+++ b/frontend/src/model/__tests__/ConvertDataFormat.test.js
@@ -148,7 +148,7 @@ describe("convertDeviceToDataObject function", () => {
     const axiosReceiverToLocal = JSON.stringify(
       convertDeviceToDataObject(sampleAxiosReceiver)
     );
-    
+
     expect(axiosSenderToLocal).toStrictEqual(JSON.stringify(sampleLocalSender));
     expect(axiosReceiverToLocal).toStrictEqual(
       JSON.stringify(sampleLocalReceiver)
@@ -164,7 +164,7 @@ describe("convertToServiceObject function", () => {
     const localReceiverToAxios = JSON.stringify(
       convertToServiceObject(sampleLocalReceiver)
     );
-    
+
     expect(localSenderToAxios).toStrictEqual(JSON.stringify(sampleAxiosSender));
     expect(localReceiverToAxios).toStrictEqual(
       JSON.stringify(sampleAxiosReceiver)
@@ -175,7 +175,7 @@ describe("convertToServiceObject function", () => {
 describe("convertStatsToDataObject function", () => {
   it("returns a StreamStatisticsInfo object with correct data", () => {
     const dbStatsToLocal = convertStatsToDataObject(sampleDBStats);
-    
+
     expect(dbStatsToLocal).toStrictEqual(sampleLocalStats);
   });
 });


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->
In the interest of keeping PRs easier to eat: here is a baby PR that's just my models and the API stuff. 
All changes taken from #430 so you can rest assured that the setup works well with the future work!

**Issue number**:  related to #271

**Task description**: 
 - Add models for StreamStatisticsInfo (+ additional models for Link, Window, Sending, stats & Receiving stats)
 - Add Api call to get stream stats
 - Update ConvertData file to convert stream stats response into appropriately structured frontend object

# Testing

**Test coverage**:
- 100%

# Additional notes

**To do before merging**:
- [x] smile with me :)
