### PR TITLE
Refactor add small dashboard card button

### DIFF
--- a/frontend/src/deviceDetailsPage/cards/DeviceChannelCard.jsx
+++ b/frontend/src/deviceDetailsPage/cards/DeviceChannelCard.jsx
@@ -13,10 +13,8 @@ export default function DeviceChannelCard(props) {
 
   return (
     <DashboardCard title="Channels">
-      <Grid container justify="center" direction="row" spacing={3}>
-        <Grid item xs={12}>
-          <ChannelDetailsTable channels={channels} />
-        </Grid>
+      <Grid item xs={12}>
+        <ChannelDetailsTable channels={channels} />
       </Grid>
     </DashboardCard>
   );

--- a/frontend/src/deviceDetailsPage/cards/DeviceInfoCard.jsx
+++ b/frontend/src/deviceDetailsPage/cards/DeviceInfoCard.jsx
@@ -11,10 +11,8 @@ export default function DeviceInfoCard(props) {
 
   return (
     <DashboardCard title="Device Info">
-      <Grid container justify="center" direction="row" spacing={3}>
-        <Grid item xs={12}>
-          <DeviceDetailsInfoTable device={device} />
-        </Grid>
+      <Grid item xs={12}>
+        <DeviceDetailsInfoTable device={device} />
       </Grid>
     </DashboardCard>
   );

--- a/frontend/src/deviceDetailsPage/cards/DeviceLogCard.jsx
+++ b/frontend/src/deviceDetailsPage/cards/DeviceLogCard.jsx
@@ -11,10 +11,8 @@ export default function DeviceLogCard(props) {
 
   return (
     <DashboardCard title="Logs">
-      <Grid container justify="center" direction="row" spacing={3}>
-        <Grid item xs={12}>
-          <DeviceLogTableWrapper device={device} />
-        </Grid>
+      <Grid item xs={12}>
+        <DeviceLogTableWrapper device={device} />
       </Grid>
     </DashboardCard>
   );

--- a/frontend/src/deviceDetailsPage/cards/DeviceStreamCard.jsx
+++ b/frontend/src/deviceDetailsPage/cards/DeviceStreamCard.jsx
@@ -11,11 +11,9 @@ export default function DeviceStreamCard(props) {
 
   return (
     <DashboardCard title="Streams">
-      <Grid container justify="center" direction="row" spacing={3}>
-        <Grid item xs={12}>
-          Awaiting stream info for
-          {device.name}
-        </Grid>
+      <Grid item xs={12}>
+        Awaiting stream info for
+        {device.name}
       </Grid>
     </DashboardCard>
   );

--- a/frontend/src/deviceDetailsPage/cards/__tests__/DeviceChannelCard.test.jsx
+++ b/frontend/src/deviceDetailsPage/cards/__tests__/DeviceChannelCard.test.jsx
@@ -32,30 +32,23 @@ describe("<DeviceChannelCard/> functional component", () => {
 
       expect(dashboardCard.props().title).toBe("Channels");
     });
-    it("Contains 2 <Grid/> components", () => {
-      expect(wrapper.find(Grid)).toHaveLength(2);
-    });
-    it("First <Grid/> has expected props", () => {
-      const outerGrid = wrapper.find(Grid).first();
-      const expectedJustify = "center";
-      const expectedDirection = "row";
-      const expectedSpacing = 3;
 
-      expect(outerGrid.props().container).toBe(true);
-      expect(outerGrid.props().justify).toBe(expectedJustify);
-      expect(outerGrid.props().direction).toBe(expectedDirection);
-      expect(outerGrid.props().spacing).toBe(expectedSpacing);
-    });
-    it("Second <Grid/>  has expected props", () => {
-      const secondGrid = wrapper.find(Grid).at(1);
-      const expectedXs = 12;
+    it("Contains 1 <Grid/> component with expected props", () => {
+      expect(wrapper.find(Grid)).toHaveLength(1);
+      const props = wrapper.find(Grid).at(0).props();
+      const expected = {
+        item: true,
+        xs: 12,
+        childType: "ChannelDetailsTable"
+      };
 
-      expect(secondGrid.props().item).toBe(true);
-      expect(secondGrid.props().xs).toBe(expectedXs);
-      expect(secondGrid.props().children.type.name).toBe("ChannelDetailsTable");
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
     it("Contains 1 <ChannelDetailsTable/> component with expected props", () => {
       expect(wrapper.find(ChannelDetailsTable)).toHaveLength(1);
+
       const props = wrapper.find(ChannelDetailsTable).first().props();
       expect(props.channels).toStrictEqual(dummyChannels);
     });

--- a/frontend/src/deviceDetailsPage/cards/__tests__/DeviceInfoCard.test.jsx
+++ b/frontend/src/deviceDetailsPage/cards/__tests__/DeviceInfoCard.test.jsx
@@ -30,29 +30,18 @@ describe("<DeviceInfoCard/> functional component", () => {
 
       expect(dashboardCard.props().title).toBe("Device Info");
     });
-    it("Contains 2 <Grid/> components", () => {
-      expect(wrapper.find(Grid)).toHaveLength(2);
-    });
-    it("First <Grid/> has expected props", () => {
-      const outerGrid = wrapper.find(Grid).first();
-      const expectedJustify = "center";
-      const expectedDirection = "row";
-      const expectedSpacing = 3;
+    it("Contains 1 <Grid/> component with expected props", () => {
+      expect(wrapper.find(Grid)).toHaveLength(1);
+      const props = wrapper.find(Grid).at(0).props();
+      const expected={
+        item: true,
+        xs : 12,
+        childType:"DeviceDetailsInfoTable"
+      };
 
-      expect(outerGrid.props().container).toBe(true);
-      expect(outerGrid.props().justify).toBe(expectedJustify);
-      expect(outerGrid.props().direction).toBe(expectedDirection);
-      expect(outerGrid.props().spacing).toBe(expectedSpacing);
-    });
-    it("Second <Grid/>  has expected props", () => {
-      const secondGrid = wrapper.find(Grid).at(1);
-      const expectedXs = 12;
-
-      expect(secondGrid.props().item).toBe(true);
-      expect(secondGrid.props().xs).toBe(expectedXs);
-      expect(secondGrid.props().children.type.name).toBe(
-        "DeviceDetailsInfoTable"
-      );
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
     it("Contains 1 <DeviceDetailsInfoTable/> component with expected props", () => {
       expect(wrapper.find(DeviceDetailsInfoTable)).toHaveLength(1);

--- a/frontend/src/deviceDetailsPage/cards/__tests__/DeviceInfoCard.test.jsx
+++ b/frontend/src/deviceDetailsPage/cards/__tests__/DeviceInfoCard.test.jsx
@@ -33,10 +33,10 @@ describe("<DeviceInfoCard/> functional component", () => {
     it("Contains 1 <Grid/> component with expected props", () => {
       expect(wrapper.find(Grid)).toHaveLength(1);
       const props = wrapper.find(Grid).at(0).props();
-      const expected={
+      const expected = {
         item: true,
-        xs : 12,
-        childType:"DeviceDetailsInfoTable"
+        xs: 12,
+        childType: "DeviceDetailsInfoTable"
       };
 
       expect(props.item).toBe(expected.item);

--- a/frontend/src/deviceDetailsPage/cards/__tests__/DeviceLogCard.test.jsx
+++ b/frontend/src/deviceDetailsPage/cards/__tests__/DeviceLogCard.test.jsx
@@ -30,29 +30,18 @@ describe("<DeviceLogCard/> functional component", () => {
 
       expect(dashboardCard.props().title).toBe("Logs");
     });
-    it("Contains 2 <Grid/> components", () => {
-      expect(wrapper.find(Grid)).toHaveLength(2);
-    });
-    it("First <Grid/> has expected props", () => {
-      const outerGrid = wrapper.find(Grid).first();
-      const expectedJustify = "center";
-      const expectedDirection = "row";
-      const expectedSpacing = 3;
+    it("Contains 1 <Grid/> component with expected props", () => {
+      expect(wrapper.find(Grid)).toHaveLength(1);
+      const props = wrapper.find(Grid).at(0).props();
+      const expected={
+        item: true,
+        xs : 12,
+        childType:"DeviceLogTableWrapper"
+      };
 
-      expect(outerGrid.props().container).toBe(true);
-      expect(outerGrid.props().justify).toBe(expectedJustify);
-      expect(outerGrid.props().direction).toBe(expectedDirection);
-      expect(outerGrid.props().spacing).toBe(expectedSpacing);
-    });
-    it("Second <Grid/>  has expected props", () => {
-      const secondGrid = wrapper.find(Grid).at(1);
-      const expectedXs = 12;
-
-      expect(secondGrid.props().item).toBe(true);
-      expect(secondGrid.props().xs).toBe(expectedXs);
-      expect(secondGrid.props().children.type.name).toBe(
-        "DeviceLogTableWrapper"
-      );
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
     it("Contains 1 <DeviceLogTableWrapper/> component with expected props", () => {
       expect(wrapper.find(DeviceLogTableWrapper)).toHaveLength(1);

--- a/frontend/src/deviceDetailsPage/cards/__tests__/DeviceLogCard.test.jsx
+++ b/frontend/src/deviceDetailsPage/cards/__tests__/DeviceLogCard.test.jsx
@@ -33,10 +33,10 @@ describe("<DeviceLogCard/> functional component", () => {
     it("Contains 1 <Grid/> component with expected props", () => {
       expect(wrapper.find(Grid)).toHaveLength(1);
       const props = wrapper.find(Grid).at(0).props();
-      const expected={
+      const expected = {
         item: true,
-        xs : 12,
-        childType:"DeviceLogTableWrapper"
+        xs: 12,
+        childType: "DeviceLogTableWrapper"
       };
 
       expect(props.item).toBe(expected.item);

--- a/frontend/src/deviceDetailsPage/cards/__tests__/DeviceStreamCard.test.jsx
+++ b/frontend/src/deviceDetailsPage/cards/__tests__/DeviceStreamCard.test.jsx
@@ -29,26 +29,16 @@ describe("<DeviceStreamCard/> functional component", () => {
 
       expect(dashboardCard.props().title).toBe("Streams");
     });
-    it("Contains 2 <Grid/> components", () => {
-      expect(wrapper.find(Grid)).toHaveLength(2);
-    });
-    it("First <Grid/> has expected props", () => {
-      const outerGrid = wrapper.find(Grid).first();
-      const expectedJustify = "center";
-      const expectedDirection = "row";
-      const expectedSpacing = 3;
+    it("Contains 1 <Grid/> component with expected props", () => {
+      expect(wrapper.find(Grid)).toHaveLength(1);
+      const props = wrapper.find(Grid).at(0).props();
+      const expected={
+        item: true,
+        xs : 12
+      };
 
-      expect(outerGrid.props().container).toBe(true);
-      expect(outerGrid.props().justify).toBe(expectedJustify);
-      expect(outerGrid.props().direction).toBe(expectedDirection);
-      expect(outerGrid.props().spacing).toBe(expectedSpacing);
-    });
-    it("Second <Grid/>  has expected props", () => {
-      const secondGrid = wrapper.find(Grid).at(1);
-      const expectedXs = 12;
-
-      expect(secondGrid.props().item).toBe(true);
-      expect(secondGrid.props().xs).toBe(expectedXs);
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
     });
   });
 });

--- a/frontend/src/deviceDetailsPage/cards/__tests__/DeviceStreamCard.test.jsx
+++ b/frontend/src/deviceDetailsPage/cards/__tests__/DeviceStreamCard.test.jsx
@@ -32,9 +32,9 @@ describe("<DeviceStreamCard/> functional component", () => {
     it("Contains 1 <Grid/> component with expected props", () => {
       expect(wrapper.find(Grid)).toHaveLength(1);
       const props = wrapper.find(Grid).at(0).props();
-      const expected={
+      const expected = {
         item: true,
-        xs : 12
+        xs: 12
       };
 
       expect(props.item).toBe(expected.item);

--- a/frontend/src/general/dashboard/ButtonInfo.js
+++ b/frontend/src/general/dashboard/ButtonInfo.js
@@ -1,0 +1,7 @@
+export default class ButtonInfo {
+  constructor(pathname, referenceObject, buttonText) {
+    this.pathname = pathname;
+    this.referenceObject = referenceObject;
+    this.buttonText = buttonText;
+  }
+}

--- a/frontend/src/general/dashboard/DashboardCard.jsx
+++ b/frontend/src/general/dashboard/DashboardCard.jsx
@@ -14,6 +14,15 @@ export default function DashboardCard(props) {
       </Typography>
       <Grid container justify="center" direction="row" spacing={3}>
         {children}
+        {button ? (
+          <Grid item xs={12}>
+            <Box className="alignRightFloatPadded">
+              <SmallCardButton button={button} />
+            </Box>
+          </Grid>
+        ) : (
+          null
+        )}
       </Grid>
     </Paper>
   );

--- a/frontend/src/general/dashboard/DashboardCard.jsx
+++ b/frontend/src/general/dashboard/DashboardCard.jsx
@@ -1,19 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
 import "./dashboard.css";
-import { Typography, Paper } from "@material-ui/core";
+import { Typography, Paper, Grid, Box } from "@material-ui/core";
+import SmallCardButton from "./SmallCardButton";
+import ButtonInfo from "./ButtonInfo";
 
 export default function DashboardCard(props) {
-  const { title, children } = props;
+  const { title, children, button } = props;
   return (
-    <>
-      <Paper className="dashboardCard" elevation={2}>
-        <Typography variant="h5" gutterBottom>
-          {title}
-        </Typography>
+    <Paper className="dashboardCard" elevation={2}>
+      <Typography variant="h5" gutterBottom>
+        {title}
+      </Typography>
+      <Grid container justify="center" direction="row" spacing={3}>
         {children}
-      </Paper>
-    </>
+      </Grid>
+    </Paper>
   );
 }
 
@@ -22,9 +24,11 @@ DashboardCard.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
-  ])
+  ]),
+  button: PropTypes.instanceOf(ButtonInfo)
 };
 
 DashboardCard.defaultProps = {
-  children: ""
+  children: "",
+  button: undefined
 };

--- a/frontend/src/general/dashboard/DashboardCard.jsx
+++ b/frontend/src/general/dashboard/DashboardCard.jsx
@@ -20,9 +20,7 @@ export default function DashboardCard(props) {
               <SmallCardButton button={button} />
             </Box>
           </Grid>
-        ) : (
-          null
-        )}
+        ) : null}
       </Grid>
     </Paper>
   );

--- a/frontend/src/general/dashboard/SmallCardButton.jsx
+++ b/frontend/src/general/dashboard/SmallCardButton.jsx
@@ -15,7 +15,7 @@ export default function SmallCardButton(props) {
       className="hideLinkStyle"
       to={{
         pathname,
-        state: { referenceObject }
+        state: referenceObject
       }}
     >
       <Button variant="contained" size="small">

--- a/frontend/src/general/dashboard/SmallCardButton.jsx
+++ b/frontend/src/general/dashboard/SmallCardButton.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "@material-ui/core";
+import { NavLink } from "react-router-dom";
+import ButtonInfo from "./ButtonInfo";
+
+export default function SmallCardButton(props) {
+  const {
+    button: { pathname, referenceObject, buttonText }
+  } = props;
+
+  return (
+    <NavLink
+      activeClassName="hideLinkStyle"
+      className="hideLinkStyle"
+      to={{
+        pathname,
+        state: { referenceObject }
+      }}
+    >
+      <Button variant="contained" size="small">
+        {buttonText}
+      </Button>
+    </NavLink>
+  );
+}
+
+SmallCardButton.propTypes = {
+  button: PropTypes.instanceOf(ButtonInfo).isRequired
+};

--- a/frontend/src/general/dashboard/__tests__/DashboardCard.test.jsx
+++ b/frontend/src/general/dashboard/__tests__/DashboardCard.test.jsx
@@ -1,9 +1,11 @@
 import React from "react";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import { describe, expect, it } from "@jest/globals";
-import { Typography, Paper } from "@material-ui/core";
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { Typography, Paper, Grid, Box } from "@material-ui/core";
 import DashboardCard from "../DashboardCard";
+import ButtonInfo from "../ButtonInfo";
+import SmallCardButton from "../SmallCardButton";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -12,19 +14,125 @@ describe("<DashboardCard/> functional Component", () => {
   const dummyTitle = "Title";
   const dummyBody = "Body";
 
-  describe(`render() with props title:${dummyTitle} children:${dummyBody}`, () => {
-    wrapper = Enzyme.shallow(
-      <DashboardCard title={dummyTitle}>{dummyBody}</DashboardCard>
-    );
-    it("Contains 1 <Paper/> component", () => {
-      expect(wrapper.find(Paper)).toHaveLength(1);
-      const paper = wrapper.find(Paper).first();
-      expect(paper.childAt(1).text()).toBe(dummyBody);
+  describe(`when prop "button" is not passed`, () => {
+    beforeAll(() => {
+      wrapper = Enzyme.shallow(
+        <DashboardCard title={dummyTitle}>{dummyBody}</DashboardCard>
+      );
     });
-    it("Contains 1 <Typography/> component", () => {
-      expect(wrapper.find(Typography)).toHaveLength(1);
-      const bodyBox = wrapper.find(Typography);
-      expect(bodyBox.text()).toBe(dummyTitle);
+
+    afterAll(() => {
+      wrapper.unmount();
+    });
+    describe(`returns a component that`, () => {
+      it("Contains 1 <Paper/> component", () => {
+        expect(wrapper.find(Paper)).toHaveLength(1);
+      });
+      it("Contains 1 <Typography/> component", () => {
+        expect(wrapper.find(Typography)).toHaveLength(1);
+        const bodyBox = wrapper.find(Typography);
+        expect(bodyBox.text()).toBe(dummyTitle);
+      });
+      it("Contains 1 <Grid/> components with expected props", () => {
+        expect(wrapper.find(Grid)).toHaveLength(1);
+        const props = wrapper.find(Grid).at(0).props();
+        const expected = {
+          container: true,
+          justify: "center",
+          direction: "row",
+          spacing: 3,
+          children: [dummyBody, null]
+        };
+
+        expect(props.container).toBe(expected.container);
+        expect(props.justify).toBe(expected.justify);
+        expect(props.direction).toBe(expected.direction);
+        expect(props.spacing).toBe(expected.spacing);
+        expect(props.children).toStrictEqual(expected.children);
+      });
+    });
+  });
+  describe(`when prop "button" is passed`, () => {
+    const dummyObj = { thing: "thing" };
+    const button = new ButtonInfo("path", dummyObj, "buttonText");
+    beforeAll(() => {
+      wrapper = Enzyme.shallow(
+        <DashboardCard title={dummyTitle} button={button}>
+          {dummyBody}
+        </DashboardCard>
+      );
+    });
+
+    afterAll(() => {
+      wrapper.unmount();
+    });
+    describe(`returns a component that`, () => {
+      it("Contains 1 <Paper/> component", () => {
+        expect(wrapper.find(Paper)).toHaveLength(1);
+        const props = wrapper.find(Paper).first().props();
+        const expected = {
+          className: "dashboardCard",
+          elevation: 2
+        };
+
+        expect(props.className).toBe(expected.className);
+        expect(props.elevation).toBe(expected.elevation);
+      });
+      it("Contains 1 <Typography/> component", () => {
+        expect(wrapper.find(Typography)).toHaveLength(1);
+        const bodyBox = wrapper.find(Typography);
+        expect(bodyBox.text()).toBe(dummyTitle);
+      });
+      it("Contains 2 <Grid/> components with expected props", () => {
+        expect(wrapper.find(Grid)).toHaveLength(2);
+      });
+      it("<GridComponent/> 0 contains expected props", () => {
+        const props = wrapper.find(Grid).at(0).props();
+        const expected = {
+          container: true,
+          justify: "center",
+          direction: "row",
+          spacing: 3,
+          children: [dummyBody]
+        };
+
+        expect(props.container).toBe(expected.container);
+        expect(props.justify).toBe(expected.justify);
+        expect(props.direction).toBe(expected.direction);
+        expect(props.spacing).toBe(expected.spacing);
+        expect(props.children).toHaveLength(2);
+        expect(props.children[0]).toBe(expected.children[0]);
+      });
+      it("<GridComponent/> 1 contains expected props", () => {
+        const props = wrapper.find(Grid).at(1).props();
+        const expected = {
+          item: true,
+          xs: 12
+        };
+
+        expect(props.item).toBe(expected.item);
+        expect(props.xs).toBe(expected.xs);
+      });
+      it("Contains 1 <SmallCardButton/> components with expected props", () => {
+        const component = wrapper.find(SmallCardButton);
+        expect(component).toHaveLength(1);
+
+        const props = component.at(0).props();
+        const expected = {
+          button
+        };
+        expect(props.button).toBe(expected.button);
+      });
+      it("Contains 1 <Box/> components with expected props", () => {
+        const component = wrapper.find(Box);
+        expect(component).toHaveLength(1);
+
+        const props = component.at(0).props();
+        const expected = {
+          className: "alignRightFloatPadded"
+        };
+        expect(props.className).toBe(expected.className);
+      });
     });
   });
 });

--- a/frontend/src/general/dashboard/__tests__/SmallCardButton.test.jsx
+++ b/frontend/src/general/dashboard/__tests__/SmallCardButton.test.jsx
@@ -11,51 +11,48 @@ import ButtonInfo from "../ButtonInfo";
 Enzyme.configure({ adapter: new Adapter() });
 
 describe("<SmallCardButton/> functional Component", () => {
-    let wrapper;
-    const dummyPath = "dumbPath";
-    const dummyObj = { thing: "thing" };
-    const dummyButtonText = "buttonText";
-    const button = new ButtonInfo(dummyPath, dummyObj, dummyButtonText);
+  let wrapper;
+  const dummyPath = "dumbPath";
+  const dummyObj = { thing: "thing" };
+  const dummyButtonText = "buttonText";
+  const button = new ButtonInfo(dummyPath, dummyObj, dummyButtonText);
 
-        beforeAll(() => {
-            wrapper = Enzyme.shallow(
-                <SmallCardButton button={button}/>
-            );
-        });
+  beforeAll(() => {
+    wrapper = Enzyme.shallow(<SmallCardButton button={button} />);
+  });
 
-        afterAll(() => {
-            wrapper.unmount();
-        });
-        describe(`returns a component that`, () => {
-            it("Contains 1 <NavLink/> components with expected props", () => {
-                expect(wrapper.find(NavLink)).toHaveLength(1);
-                const props = wrapper.find(NavLink).at(0).props();
-                const expected = {
-                    activeClassName:"hideLinkStyle",
-                    className:"hideLinkStyle",
-                    to:{
-                      pathname: dummyPath,
-                      state: dummyObj
-                    }
-                };
+  afterAll(() => {
+    wrapper.unmount();
+  });
+  describe(`returns a component that`, () => {
+    it("Contains 1 <NavLink/> components with expected props", () => {
+      expect(wrapper.find(NavLink)).toHaveLength(1);
+      const props = wrapper.find(NavLink).at(0).props();
+      const expected = {
+        activeClassName: "hideLinkStyle",
+        className: "hideLinkStyle",
+        to: {
+          pathname: dummyPath,
+          state: dummyObj
+        }
+      };
 
-                expect(props.activeClassName).toBe(expected.activeClassName);
-                expect(props.className).toBe(expected.className);
-                expect(props.to).toStrictEqual(expected.to);
-            });
-            it("Contains 1 <Button/> components with expected props", () => {
-                expect(wrapper.find(Button)).toHaveLength(1);
-                const props = wrapper.find(Button).at(0).props();
-                const expected = {
-                    variant:"contained",
-                    size:"small",
-                    children: dummyButtonText
-                };
+      expect(props.activeClassName).toBe(expected.activeClassName);
+      expect(props.className).toBe(expected.className);
+      expect(props.to).toStrictEqual(expected.to);
+    });
+    it("Contains 1 <Button/> components with expected props", () => {
+      expect(wrapper.find(Button)).toHaveLength(1);
+      const props = wrapper.find(Button).at(0).props();
+      const expected = {
+        variant: "contained",
+        size: "small",
+        children: dummyButtonText
+      };
 
-                expect(props.variant).toBe(expected.variant);
-                expect(props.size).toBe(expected.size);
-                expect(props.children).toStrictEqual(expected.children);
-            });
-        });
-
+      expect(props.variant).toBe(expected.variant);
+      expect(props.size).toBe(expected.size);
+      expect(props.children).toStrictEqual(expected.children);
+    });
+  });
 });

--- a/frontend/src/general/dashboard/__tests__/SmallCardButton.test.jsx
+++ b/frontend/src/general/dashboard/__tests__/SmallCardButton.test.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { NavLink } from "react-router-dom";
+import { Button } from "@material-ui/core";
+
+import SmallCardButton from "../SmallCardButton";
+import ButtonInfo from "../ButtonInfo";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("<SmallCardButton/> functional Component", () => {
+    let wrapper;
+    const dummyPath = "dumbPath";
+    const dummyObj = { thing: "thing" };
+    const dummyButtonText = "buttonText";
+    const button = new ButtonInfo(dummyPath, dummyObj, dummyButtonText);
+
+        beforeAll(() => {
+            wrapper = Enzyme.shallow(
+                <SmallCardButton button={button}/>
+            );
+        });
+
+        afterAll(() => {
+            wrapper.unmount();
+        });
+        describe(`returns a component that`, () => {
+            it("Contains 1 <NavLink/> components with expected props", () => {
+                expect(wrapper.find(NavLink)).toHaveLength(1);
+                const props = wrapper.find(NavLink).at(0).props();
+                const expected = {
+                    activeClassName:"hideLinkStyle",
+                    className:"hideLinkStyle",
+                    to:{
+                      pathname: dummyPath,
+                      state: dummyObj
+                    }
+                };
+
+                expect(props.activeClassName).toBe(expected.activeClassName);
+                expect(props.className).toBe(expected.className);
+                expect(props.to).toStrictEqual(expected.to);
+            });
+            it("Contains 1 <Button/> components with expected props", () => {
+                expect(wrapper.find(Button)).toHaveLength(1);
+                const props = wrapper.find(Button).at(0).props();
+                const expected = {
+                    variant:"contained",
+                    size:"small",
+                    children: dummyButtonText
+                };
+
+                expect(props.variant).toBe(expected.variant);
+                expect(props.size).toBe(expected.size);
+                expect(props.children).toStrictEqual(expected.children);
+            });
+        });
+
+});

--- a/frontend/src/homepage/ActiveStreamCard.jsx
+++ b/frontend/src/homepage/ActiveStreamCard.jsx
@@ -12,16 +12,14 @@ export default function ActiveStreamCard() {
 
   return (
     <DashboardCard title="Active Streams" style={{ height: "100%" }}>
-      <Grid container justify="center" direction="row" spacing={3}>
-        <Grid item xs={12}>
-          <StreamsTableWrapper dataSource={dataSource} />
-        </Grid>
-        <Grid item xs={4}>
-          <DashBoardButton href="/Streams">See more</DashBoardButton>
-        </Grid>
-        <Grid item xs={4}>
-          <DashBoardButton href="/Streams/New">Start Stream</DashBoardButton>
-        </Grid>
+      <Grid item xs={12}>
+        <StreamsTableWrapper dataSource={dataSource} />
+      </Grid>
+      <Grid item xs={4}>
+        <DashBoardButton href="/Streams">See more</DashBoardButton>
+      </Grid>
+      <Grid item xs={4}>
+        <DashBoardButton href="/Streams/New">Start Stream</DashBoardButton>
       </Grid>
     </DashboardCard>
   );

--- a/frontend/src/homepage/ActivityLogCard.jsx
+++ b/frontend/src/homepage/ActivityLogCard.jsx
@@ -7,10 +7,8 @@ import DashBoardButton from "../general/dashboard/DashboardButton";
 export default function ActivityLogCard() {
   return (
     <DashboardCard title="Activity Logs">
-      <Grid container justify="center" direction="row" spacing={3}>
-        <Grid item xs={4}>
-          <DashBoardButton href="/Logs">View All</DashBoardButton>
-        </Grid>
+      <Grid item xs={4}>
+        <DashBoardButton href="/Logs">View All</DashBoardButton>
       </Grid>
     </DashboardCard>
   );

--- a/frontend/src/homepage/AdminPanelCard.jsx
+++ b/frontend/src/homepage/AdminPanelCard.jsx
@@ -7,13 +7,11 @@ import DashBoardButton from "../general/dashboard/DashboardButton";
 export default function AdminPanelCard() {
   return (
     <DashboardCard title="Admin Panel">
-      <Grid container justify="center" direction="row" spacing={3}>
-        <Grid item xs={4}>
-          <DashBoardButton href="/Admin">View Users</DashBoardButton>
-        </Grid>
-        <Grid item xs={4}>
-          <DashBoardButton href="/Admin/New">Create a User</DashBoardButton>
-        </Grid>
+      <Grid item xs={4}>
+        <DashBoardButton href="/Admin">View Users</DashBoardButton>
+      </Grid>
+      <Grid item xs={4}>
+        <DashBoardButton href="/Admin/New">Create a User</DashBoardButton>
       </Grid>
     </DashboardCard>
   );

--- a/frontend/src/homepage/DevicesCard.jsx
+++ b/frontend/src/homepage/DevicesCard.jsx
@@ -7,14 +7,12 @@ import DashBoardButton from "../general/dashboard/DashboardButton";
 export default function DevicesCard() {
   return (
     <DashboardCard title="Devices">
-      <Grid container justify="center" direction="row" spacing={3}>
         <Grid item xs={4}>
           <DashBoardButton href="/Devices">View Senders</DashBoardButton>
         </Grid>
         <Grid item xs={4}>
           <DashBoardButton href="/Devices">View Receivers</DashBoardButton>
         </Grid>
-      </Grid>
     </DashboardCard>
   );
 }

--- a/frontend/src/homepage/DevicesCard.jsx
+++ b/frontend/src/homepage/DevicesCard.jsx
@@ -7,12 +7,12 @@ import DashBoardButton from "../general/dashboard/DashboardButton";
 export default function DevicesCard() {
   return (
     <DashboardCard title="Devices">
-        <Grid item xs={4}>
-          <DashBoardButton href="/Devices">View Senders</DashBoardButton>
-        </Grid>
-        <Grid item xs={4}>
-          <DashBoardButton href="/Devices">View Receivers</DashBoardButton>
-        </Grid>
+      <Grid item xs={4}>
+        <DashBoardButton href="/Devices">View Senders</DashBoardButton>
+      </Grid>
+      <Grid item xs={4}>
+        <DashBoardButton href="/Devices">View Receivers</DashBoardButton>
+      </Grid>
     </DashboardCard>
   );
 }

--- a/frontend/src/homepage/__tests__/ActiveStreamCard.test.jsx
+++ b/frontend/src/homepage/__tests__/ActiveStreamCard.test.jsx
@@ -25,41 +25,41 @@ describe("<ActiveStreamCard/> functional Component", () => {
       expect(styleProperty.height).toBe("100%");
     });
 
-    it("Contains 4 <Grid/> components", () => {
-      expect(wrapper.find(Grid)).toHaveLength(4);
+    it("Contains 3 <Grid/> components", () => {
+      expect(wrapper.find(Grid)).toHaveLength(3);
     });
-    it("First <Grid/> has expected props", () => {
-      const outerGrid = wrapper.find(Grid).first();
-      const expectedJustify = "center";
-      const expectedDirection = "row";
-      const expectedSpacing = 3;
-
-      expect(outerGrid.props().container).toBe(true);
-      expect(outerGrid.props().justify).toBe(expectedJustify);
-      expect(outerGrid.props().direction).toBe(expectedDirection);
-      expect(outerGrid.props().spacing).toBe(expectedSpacing);
+    it("<Grid/> 0 has expected props", () => {
+      const props = wrapper.find(Grid).at(0).props();
+      const expected = {
+        item: true,
+        xs: 12,
+        childType: "StreamsTableWrapper"
+      };
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
-    it("Second <Grid/> has expected props", () => {
-      const secondGrid = wrapper.find(Grid).at(1);
-      const expectedXs = 12;
-      expect(secondGrid.props().item).toBe(true);
-      expect(secondGrid.props().xs).toBe(expectedXs);
-      expect(secondGrid.props().children.type.name).toBe("StreamsTableWrapper");
+    it("<Grid/> 1 has expected props", () => {
+      const props = wrapper.find(Grid).at(1).props();
+      const expected = {
+        item: true,
+        xs: 4,
+        childType: "DashboardButton"
+      };
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
-    it("Third <Grid/> has expected props", () => {
-      const thirdGrid = wrapper.find(Grid).at(2);
-      const expectedXs = 4;
-      expect(thirdGrid.props().item).toBe(true);
-      expect(thirdGrid.props().xs).toBe(expectedXs);
-      expect(thirdGrid.props().children.type.name).toBe("DashboardButton");
-    });
-    it("Fourth <Grid/> has expected props", () => {
-      const fourthGrid = wrapper.find(Grid).at(3);
-      const expectedXs = 4;
-      expect(fourthGrid.props().item).toBe(true);
-      expect(fourthGrid.props().xs).toBe(expectedXs);
-
-      expect(fourthGrid.props().children.type.name).toBe("DashboardButton");
+    it("<Grid/> 2 has expected props", () => {
+      const props = wrapper.find(Grid).at(2).props();
+      const expected = {
+        item: true,
+        xs: 4,
+        childType: "DashboardButton"
+      };
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
     it("Contains 1 <StreamTableWrapper/> component", () => {
       expect(wrapper.find(StreamsTableWrapper)).toHaveLength(1);

--- a/frontend/src/homepage/__tests__/ActivityLogCard.test.jsx
+++ b/frontend/src/homepage/__tests__/ActivityLogCard.test.jsx
@@ -21,34 +21,25 @@ describe("<ActivityLogCard/> functional component", () => {
       const dashboardCard = wrapper.find(DashboardCard).first();
       expect(dashboardCard.props().title).toBe(expectedTitle);
     });
-    it("Contains 2 <Grid/> components", () => {
-      expect(wrapper.find(Grid)).toHaveLength(2);
-    });
-    it("First <Grid/> has expected props", () => {
-      const outerGrid = wrapper.find(Grid).first();
-      const expectedJustify = "center";
-      const expectedDirection = "row";
-      const expectedSpacing = 3;
+    it("Contains 1 <Grid/> component with expected props", () => {
+      expect(wrapper.find(Grid)).toHaveLength(1);
 
-      expect(outerGrid.props().container).toBe(true);
-      expect(outerGrid.props().justify).toBe(expectedJustify);
-      expect(outerGrid.props().direction).toBe(expectedDirection);
-      expect(outerGrid.props().spacing).toBe(expectedSpacing);
-    });
-    it("Second <Grid/> has expected props", () => {
-      const secondGrid = wrapper.find(Grid).at(1);
-      const expectedXs = 4;
-
-      expect(secondGrid.props().item).toBe(true);
-      expect(secondGrid.props().xs).toBe(expectedXs);
-      expect(secondGrid.props().children.type.name).toBe("DashboardButton");
+      const props = wrapper.find(Grid).at(0).props();
+      const expected = {
+        item: true,
+        xs: 4,
+        childType: "DashboardButton"
+      };
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
     it("Contains 1 <DashboardButton/> component that  has expected props", () => {
       expect(wrapper.find(DashboardButton)).toHaveLength(1);
 
-      const firstButton = wrapper.find(DashboardButton).first();
-      expect(firstButton.props().href).toBe("/Logs");
-      expect(firstButton.props().children).toBe("View All");
+      const props = wrapper.find(DashboardButton).first().props();
+      expect(props.href).toBe("/Logs");
+      expect(props.children).toBe("View All");
     });
   });
 });

--- a/frontend/src/homepage/__tests__/AdminPanelCard.test.jsx
+++ b/frontend/src/homepage/__tests__/AdminPanelCard.test.jsx
@@ -20,36 +20,30 @@ describe("<AdminPanelCard/> functional component", () => {
 
       expect(dashboardCard.props().title).toBe("Admin Panel");
     });
-    it("Contains 3 <Grid/> components", () => {
-      expect(wrapper.find(Grid)).toHaveLength(3);
+    it("Contains 2 <Grid/> components", () => {
+      expect(wrapper.find(Grid)).toHaveLength(2);
     });
-    it("First <Grid/> has expected props", () => {
-      const outerGrid = wrapper.find(Grid).first();
-      const expectedJustify = "center";
-      const expectedDirection = "row";
-      const expectedSpacing = 3;
-
-      expect(outerGrid.props().container).toBe(true);
-      expect(outerGrid.props().justify).toBe(expectedJustify);
-      expect(outerGrid.props().direction).toBe(expectedDirection);
-      expect(outerGrid.props().spacing).toBe(expectedSpacing);
+    it("<Grid/> 0 has expected props", () => {
+      const props = wrapper.find(Grid).at(0).props();
+      const expected = {
+        item: true,
+        xs: 4,
+        childType: "DashboardButton"
+      };
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
-    it("Second <Grid/>  has expected props", () => {
-      const secondGrid = wrapper.find(Grid).at(1);
-      const expectedXs = 4;
-
-      expect(secondGrid.props().item).toBe(true);
-      expect(secondGrid.props().xs).toBe(expectedXs);
-      expect(secondGrid.props().children.type.name).toBe("DashboardButton");
-    });
-    it("Third <Grid/> has expected props", () => {
-      const thirdGrid = wrapper.find(Grid).at(2);
-      const expectedXs = 4;
-
-      expect(thirdGrid.props().item).toBe(true);
-      expect(thirdGrid.props().xs).toBe(expectedXs);
-
-      expect(thirdGrid.props().children.type.name).toBe("DashboardButton");
+    it("<Grid/> 1 has expected props", () => {
+      const props = wrapper.find(Grid).at(1).props();
+      const expected = {
+        item: true,
+        xs: 4,
+        childType: "DashboardButton"
+      };
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
     describe("Contains 2 <DashboardButton/> components", () => {
       expect(wrapper.find(DashboardButton)).toHaveLength(2);

--- a/frontend/src/homepage/__tests__/DevicesCard.test.jsx
+++ b/frontend/src/homepage/__tests__/DevicesCard.test.jsx
@@ -20,49 +20,43 @@ describe("<DevicesCard/> functional component", () => {
 
       expect(dashboardCard.props().title).toBe("Devices");
     });
-    it("Contains 3 <Grid/> components", () => {
-      expect(wrapper.find(Grid)).toHaveLength(3);
+    it("Contains 2 <Grid/> components", () => {
+      expect(wrapper.find(Grid)).toHaveLength(2);
     });
-    it("First <Grid/> has expected props", () => {
-      const outerGrid = wrapper.find(Grid).first();
-      const expectedJustify = "center";
-      const expectedDirection = "row";
-      const expectedSpacing = 3;
-
-      expect(outerGrid.props().container).toBe(true);
-      expect(outerGrid.props().justify).toBe(expectedJustify);
-      expect(outerGrid.props().direction).toBe(expectedDirection);
-      expect(outerGrid.props().spacing).toBe(expectedSpacing);
+    it("<Grid/> 0 has expected props", () => {
+      const props = wrapper.find(Grid).at(0).props();
+      const expected = {
+        item: true,
+        xs: 4,
+        childType: "DashboardButton"
+      };
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
-    it("Second <Grid/>  has expected props", () => {
-      const secondGrid = wrapper.find(Grid).at(1);
-      const expectedXs = 4;
-
-      expect(secondGrid.props().item).toBe(true);
-      expect(secondGrid.props().xs).toBe(expectedXs);
-      expect(secondGrid.props().children.type.name).toBe("DashboardButton");
+    it("<Grid/> 1 has expected props", () => {
+      const props = wrapper.find(Grid).at(1).props();
+      const expected = {
+        item: true,
+        xs: 4,
+        childType: "DashboardButton"
+      };
+      expect(props.item).toBe(expected.item);
+      expect(props.xs).toBe(expected.xs);
+      expect(props.children.type.name).toBe(expected.childType);
     });
-    it("Third <Grid/> has expected props", () => {
-      const thirdGrid = wrapper.find(Grid).at(2);
-      const expectedXs = 4;
-
-      expect(thirdGrid.props().item).toBe(true);
-      expect(thirdGrid.props().xs).toBe(expectedXs);
-
-      expect(thirdGrid.props().children.type.name).toBe("DashboardButton");
-    });
-    describe("Contains 2 <DashboardButton/> components", () => {
+    it("Contains 2 <DashboardButton/> components", () => {
       expect(wrapper.find(DashboardButton)).toHaveLength(2);
-      it("First <DashboardButton/> has expected props", () => {
-        const firstButton = wrapper.find(DashboardButton).first();
-        expect(firstButton.props().href).toBe("/Devices");
-        expect(firstButton.props().children).toBe("View Senders");
-      });
-      describe("Second <DashboardButton/> has expected props", () => {
-        const secondButton = wrapper.find(DashboardButton).at(1);
-        expect(secondButton.props().href).toBe("/Devices");
-        expect(secondButton.props().children).toBe("View Receivers");
-      });
+    });
+    it("First <DashboardButton/> has expected props", () => {
+      const props = wrapper.find(DashboardButton).at(0).props();
+      expect(props.href).toBe("/Devices");
+      expect(props.children).toBe("View Senders");
+    });
+    describe("Second <DashboardButton/> has expected props", () => {
+      const props = wrapper.find(DashboardButton).at(1).props();
+      expect(props.href).toBe("/Devices");
+      expect(props.children).toBe("View Receivers");
     });
   });
 });

--- a/frontend/src/streamDetails/StreamDetailsPageContents.jsx
+++ b/frontend/src/streamDetails/StreamDetailsPageContents.jsx
@@ -12,7 +12,7 @@ export default function StreamDetailsPageContents(props) {
   const { stream } = props;
   const button = new ButtonInfo(
     `/Devices/Details/${stream.sender.serialNumber}`,
-    stream.sender,
+    { device: stream.sender },
     "View Device"
   );
   return (

--- a/frontend/src/streamDetails/StreamDetailsPageContents.jsx
+++ b/frontend/src/streamDetails/StreamDetailsPageContents.jsx
@@ -6,14 +6,20 @@ import StreamInfo from "../model/StreamInfo";
 import DashboardCard from "../general/dashboard/DashboardCard";
 import StreamDeviceDetails from "./StreamDeviceDetails";
 import DeleteStreamDialogOpener from "./DeleteStreamDialogOpener";
+import ButtonInfo from "../general/dashboard/ButtonInfo";
 
 export default function StreamDetailsPageContents(props) {
   const { stream } = props;
+  const button = new ButtonInfo(
+    `/Devices/Details/${stream.sender.serialNumber}`,
+    stream.sender,
+    "View Device"
+  );
   return (
     <Container>
       <Grid container spacing={3}>
         <Grid item xs={6}>
-          <DashboardCard title="Sender Details">
+          <DashboardCard title="Sender Details" button={button}>
             <StreamDeviceDetails
               device={stream.sender}
               channel={stream.outputChannel}


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: <!--Issue Number-->N/A

**Task description**: 

 - Refactor DashBoardCard to have Grid container around children
   - adapt all HOC that use DashboardCards accordingly and update their tests 
 - Create SmallCardButton and ButtonInfo objects for the dashabord card
 - Added conditional rendering for SmallCardButton using new optional button prop


 
<!-- What changed? What does this do? Provide screenshots if necessary--> 
| Original   | Updated|
|:---------------:|:---------------:|
|n/a |![image](https://user-images.githubusercontent.com/35614138/113096406-18767a00-91c3-11eb-99e8-9ca15bf389dc.png)
 |

# Testing

**Test coverage**:
<!-- Unit tested/manual testing only/ Some actual metrics -->

# Additional notes

**Note to reviewers**:
<!-- Special instructions for testing this code-->
To try this out, add the following to a card. I used the cards in StreamDetailsPageContents, since that's where these will be used, though these components are undergoing changes in #430 so the buttonCard will be implemented there or afterwards
``` javascript
+ import ButtonInfo from "../general/dashboard/ButtonInfo";
```
``` javascript
  const button = new ButtonInfo(
    `somePathName/${someDeviceInfo.serialNumber}`,
    {device: someDeviceInfo},
    "buttonTitle"
  );

<DashboardCard title="someTitle" button={button}>
```

**To do before merging**:
