### PR TITLE
[#443] Fix Device Stealing

### DIFF
--- a/src/main/java/org/beanpod/switchboard/controller/DeviceController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/DeviceController.java
@@ -64,7 +64,7 @@ public class DeviceController implements DeviceApi {
     String publicIpAddress = request.getRemoteAddr();
 
     Optional<DeviceDto> deviceLookup =
-        deviceDao.findDevice(user, createDeviceRequest.getSerialNumber());
+        deviceDao.findDevice(createDeviceRequest.getSerialNumber());
     if (deviceLookup.isPresent()) {
       throw new ExceptionType.DeviceAlreadyExistsException(createDeviceRequest.getSerialNumber());
     }

--- a/src/main/java/org/beanpod/switchboard/controller/DeviceController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/DeviceController.java
@@ -63,8 +63,7 @@ public class DeviceController implements DeviceApi {
     UserEntity user = userDao.findUser(request.getUserPrincipal().getName());
     String publicIpAddress = request.getRemoteAddr();
 
-    Optional<DeviceDto> deviceLookup =
-        deviceDao.findDevice(createDeviceRequest.getSerialNumber());
+    Optional<DeviceDto> deviceLookup = deviceDao.findDevice(createDeviceRequest.getSerialNumber());
     if (deviceLookup.isPresent()) {
       throw new ExceptionType.DeviceAlreadyExistsException(createDeviceRequest.getSerialNumber());
     }

--- a/src/main/java/org/beanpod/switchboard/dao/DeviceDaoImpl.java
+++ b/src/main/java/org/beanpod/switchboard/dao/DeviceDaoImpl.java
@@ -40,9 +40,7 @@ public class DeviceDaoImpl {
   }
 
   public Optional<DeviceDto> findDevice(String serialNumber) {
-    return deviceRepository
-        .findDeviceBySerialNumber(serialNumber)
-        .map(deviceMapper::toDeviceDto);
+    return deviceRepository.findDeviceBySerialNumber(serialNumber).map(deviceMapper::toDeviceDto);
   }
 
   public Optional<DeviceDto> findDevice(UserEntity user, String serialNumber) {

--- a/src/main/java/org/beanpod/switchboard/dao/DeviceDaoImpl.java
+++ b/src/main/java/org/beanpod/switchboard/dao/DeviceDaoImpl.java
@@ -39,6 +39,12 @@ public class DeviceDaoImpl {
     return deviceRepository.findDeviceEntitiesByUser(user);
   }
 
+  public Optional<DeviceDto> findDevice(String serialNumber) {
+    return deviceRepository
+        .findDeviceBySerialNumber(serialNumber)
+        .map(deviceMapper::toDeviceDto);
+  }
+
   public Optional<DeviceDto> findDevice(UserEntity user, String serialNumber) {
     return deviceRepository
         .findDeviceByUserAndSerialNumber(user, serialNumber)

--- a/src/main/java/org/beanpod/switchboard/repository/DeviceRepository.java
+++ b/src/main/java/org/beanpod/switchboard/repository/DeviceRepository.java
@@ -14,6 +14,8 @@ public interface DeviceRepository extends JpaRepository<DeviceEntity, String> {
 
   List<DeviceEntity> findDeviceEntitiesByUser(UserEntity user);
 
+  Optional<DeviceEntity> findDeviceBySerialNumber(String serialNumber);
+
   Optional<DeviceEntity> findDeviceByUserAndSerialNumber(UserEntity user, String serialNumber);
 
   Long deleteDeviceEntitiesByUserAndSerialNumber(UserEntity user, String serialNumber);

--- a/src/test/java/org/beanpod/switchboard/controller/DeviceControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/DeviceControllerTest.java
@@ -106,7 +106,7 @@ class DeviceControllerTest {
   // When a device is unavailable in the DB
   @Test
   final void testCreateDeviceAlreadyExists() {
-    when(deviceDao.findDevice(user, DeviceFixture.SERIAL_NUMBER))
+    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER))
         .thenReturn(Optional.of(deviceDTO));
 
     assertThrows(

--- a/src/test/java/org/beanpod/switchboard/controller/DeviceControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/DeviceControllerTest.java
@@ -106,8 +106,7 @@ class DeviceControllerTest {
   // When a device is unavailable in the DB
   @Test
   final void testCreateDeviceAlreadyExists() {
-    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER))
-        .thenReturn(Optional.of(deviceDTO));
+    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER)).thenReturn(Optional.of(deviceDTO));
 
     assertThrows(
         ExceptionType.DeviceAlreadyExistsException.class,


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->
The create device action looks up the entire list of devices rather than the user's list of devices to avoid "device stealing".

**Issue number**: #443

**Task description**: 

 - Update createDevice method in DeviceController to lookup entire list of devices as to not override existing devices that belong to another user.

# Testing

**Test coverage**:
No change.

# Additional notes

**Note to reviewers**: n/a

**To do before merging**: n/a
