### PR TITLE
[#451] Refactor breadcrumbs links

### DIFF
--- a/frontend/src/deviceDetailsPage/DeviceDetailsPage.jsx
+++ b/frontend/src/deviceDetailsPage/DeviceDetailsPage.jsx
@@ -16,7 +16,7 @@ export default function DeviceDetailsPage(props) {
   const breadcrumbs = [
     ["Home", "/Home"],
     ["My Devices", "/Devices"],
-    ["Device Details", `/Devices/Details/${device.serialNumber}`, {device}]
+    ["Device Details", `/Devices/Details/${device.serialNumber}`, { device }]
   ];
 
   return (

--- a/frontend/src/deviceDetailsPage/DeviceDetailsPage.jsx
+++ b/frontend/src/deviceDetailsPage/DeviceDetailsPage.jsx
@@ -16,7 +16,7 @@ export default function DeviceDetailsPage(props) {
   const breadcrumbs = [
     ["Home", "/Home"],
     ["My Devices", "/Devices"],
-    ["Device Details", `/Devices/Details/${device.serialNumber}`]
+    ["Device Details", `/Devices/Details/${device.serialNumber}`, {device}]
   ];
 
   return (

--- a/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsPage.test.jsx
+++ b/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsPage.test.jsx
@@ -38,7 +38,7 @@ describe("<DeviceDetailsPage/> functional Component", () => {
         const expectedBreadcumbs = [
           ["Home", "/Home"],
           ["My Devices", "/Devices"],
-          ["Device Details", `/Devices/Details/${dummyDevice.serialNumber}`]
+          ["Device Details", `/Devices/Details/${dummyDevice.serialNumber}`, { device: dummyDevice}]
         ];
 
         expect(wrapper.find(Page)).toHaveLength(1);
@@ -69,7 +69,8 @@ describe("<DeviceDetailsPage/> functional Component", () => {
           ["My Devices", "/Devices"],
           [
             "Device Details",
-            `/Devices/Details/${expectedDefaultDevice.serialNumber}`
+            `/Devices/Details/${expectedDefaultDevice.serialNumber}`,
+            {device: expectedDefaultDevice}
           ]
         ];
 

--- a/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsPage.test.jsx
+++ b/frontend/src/deviceDetailsPage/__tests__/DeviceDetailsPage.test.jsx
@@ -38,7 +38,11 @@ describe("<DeviceDetailsPage/> functional Component", () => {
         const expectedBreadcumbs = [
           ["Home", "/Home"],
           ["My Devices", "/Devices"],
-          ["Device Details", `/Devices/Details/${dummyDevice.serialNumber}`, { device: dummyDevice}]
+          [
+            "Device Details",
+            `/Devices/Details/${dummyDevice.serialNumber}`,
+            { device: dummyDevice }
+          ]
         ];
 
         expect(wrapper.find(Page)).toHaveLength(1);
@@ -70,7 +74,7 @@ describe("<DeviceDetailsPage/> functional Component", () => {
           [
             "Device Details",
             `/Devices/Details/${expectedDefaultDevice.serialNumber}`,
-            {device: expectedDefaultDevice}
+            { device: expectedDefaultDevice }
           ]
         ];
 

--- a/frontend/src/devicelist/DeviceListPageContents.jsx
+++ b/frontend/src/devicelist/DeviceListPageContents.jsx
@@ -14,6 +14,8 @@ export default class DeviceListPageContents extends React.Component {
     };
 
     this.handleChange = this.handleChange.bind(this);
+    this.getDevices = this.getDevices.bind(this);
+    this.getTitle = this.getTitle.bind(this);
     this.handleSendersChange = this.handleSendersChange.bind(this);
     this.handleReceiversChange = this.handleReceiversChange.bind(this);
   }

--- a/frontend/src/general/DynamicBreadcrumb.jsx
+++ b/frontend/src/general/DynamicBreadcrumb.jsx
@@ -2,13 +2,15 @@ import React from "react";
 import { Box, Breadcrumbs, Typography } from "@material-ui/core";
 import PropTypes from "prop-types";
 import { NavLink } from "react-router-dom";
+import { NavigateNext } from "@material-ui/icons";
 import DeviceInfo from "../model/DeviceInfo";
+import StreamInfo from "../model/StreamInfo";
 
 export default function DynamicBreadcrumb(props) {
   const { breadcrumbs } = props;
   return (
-    <Box padding="2em 0em 0em 1em">
-      <Breadcrumbs aria-label="breadcrumb" id="breadcrumbParent">
+    <Box padding="2em 0em 0em">
+      <Breadcrumbs separator={<NavigateNext fontSize="medium" />}>
         {breadcrumbs.map((crumb) => {
           return (
             <NavLink

--- a/frontend/src/general/DynamicBreadcrumb.jsx
+++ b/frontend/src/general/DynamicBreadcrumb.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Breadcrumbs, Typography } from "@material-ui/core";
+import { Box, Breadcrumbs, Link, Typography } from "@material-ui/core";
 import PropTypes from "prop-types";
 import { NavLink } from "react-router-dom";
 import { NavigateNext } from "@material-ui/icons";
@@ -10,10 +10,14 @@ export default function DynamicBreadcrumb(props) {
   const { breadcrumbs } = props;
   return (
     <Box padding="2em 0em 0em">
-      <Breadcrumbs separator={<NavigateNext fontSize="medium" />}>
+      <Breadcrumbs
+        aria-label="breadcrumb"
+        separator={<NavigateNext fontSize="medium" />}
+      >
         {breadcrumbs.map((crumb) => {
           return (
-            <NavLink
+            <Link
+              component={NavLink}
               to={{
                 pathname: crumb[1],
                 state: crumb[2] ? crumb[2] : null
@@ -21,7 +25,7 @@ export default function DynamicBreadcrumb(props) {
               key={`breadcrumb ${crumb[0]}`}
             >
               <Typography color="textPrimary">{crumb[0]}</Typography>
-            </NavLink>
+            </Link>
           );
         })}
       </Breadcrumbs>

--- a/frontend/src/general/DynamicBreadcrumb.jsx
+++ b/frontend/src/general/DynamicBreadcrumb.jsx
@@ -14,7 +14,7 @@ export default function DynamicBreadcrumb(props) {
             <NavLink
               to={{
                 pathname: crumb[1],
-                state: crumb[2]
+                state: crumb[2] ? crumb[2] : null
               }}
               key={`breadcrumb ${crumb[0]}`}
             >
@@ -28,9 +28,16 @@ export default function DynamicBreadcrumb(props) {
 }
 DynamicBreadcrumb.propTypes = {
   breadcrumbs: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.string),
-      PropTypes.instanceOf(DeviceInfo)
-    ])
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.objectOf(
+          PropTypes.oneOfType([
+            PropTypes.instanceOf(DeviceInfo),
+            PropTypes.instanceOf(StreamInfo)
+          ])
+        )
+      ])
+    )
   ).isRequired
 };

--- a/frontend/src/general/DynamicBreadcrumb.jsx
+++ b/frontend/src/general/DynamicBreadcrumb.jsx
@@ -1,22 +1,25 @@
 import React from "react";
-import { Box, Breadcrumbs, Link, Typography } from "@material-ui/core";
+import { Box, Breadcrumbs, Typography } from "@material-ui/core";
 import PropTypes from "prop-types";
+import { NavLink } from "react-router-dom";
+import DeviceInfo from "../model/DeviceInfo";
 
 export default function DynamicBreadcrumb(props) {
   const { breadcrumbs } = props;
   return (
     <Box padding="2em 0em 0em 1em">
       <Breadcrumbs aria-label="breadcrumb" id="breadcrumbParent">
-        {breadcrumbs.map((crumb, i) => {
+        {breadcrumbs.map((crumb) => {
           return (
-            <Link
-              color="inherit"
-              href={crumb[1]}
-              id={`breadcrumb${i}`}
+            <NavLink
+              to={{
+                pathname: crumb[1],
+                state: crumb[2]
+              }}
               key={`breadcrumb ${crumb[0]}`}
             >
               <Typography color="textPrimary">{crumb[0]}</Typography>
-            </Link>
+            </NavLink>
           );
         })}
       </Breadcrumbs>
@@ -24,5 +27,10 @@ export default function DynamicBreadcrumb(props) {
   );
 }
 DynamicBreadcrumb.propTypes = {
-  breadcrumbs: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired
+  breadcrumbs: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.instanceOf(DeviceInfo)
+    ])
+  ).isRequired
 };

--- a/frontend/src/general/Page.jsx
+++ b/frontend/src/general/Page.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Box, Container } from "@material-ui/core";
+import { Container } from "@material-ui/core";
 import DynamicBreadcrumb from "./DynamicBreadcrumb";
 import Title from "./Title";
 import HeaderBar from "./HeaderBar";
@@ -14,8 +14,8 @@ export default function Page(props) {
       <HeaderBar />
       <Container>
         <DynamicBreadcrumb breadcrumbs={breadcrumbs} />
-          <Title title={title} deviceList={deviceList} />
-          {children}
+        <Title title={title} deviceList={deviceList} />
+        {children}
       </Container>
     </>
   );

--- a/frontend/src/general/Page.jsx
+++ b/frontend/src/general/Page.jsx
@@ -14,10 +14,8 @@ export default function Page(props) {
       <HeaderBar />
       <Container>
         <DynamicBreadcrumb breadcrumbs={breadcrumbs} />
-        <Box className="areaUnderBreadcrumbs">
           <Title title={title} deviceList={deviceList} />
           {children}
-        </Box>
       </Container>
     </>
   );

--- a/frontend/src/general/Page.jsx
+++ b/frontend/src/general/Page.jsx
@@ -4,6 +4,8 @@ import { Box, Container } from "@material-ui/core";
 import DynamicBreadcrumb from "./DynamicBreadcrumb";
 import Title from "./Title";
 import HeaderBar from "./HeaderBar";
+import DeviceInfo from "../model/DeviceInfo";
+import StreamInfo from "../model/StreamInfo";
 
 export default function Page(props) {
   const { breadcrumbs, title, deviceList, children } = props;
@@ -22,8 +24,19 @@ export default function Page(props) {
 }
 
 Page.propTypes = {
-  breadcrumbs: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string))
-    .isRequired,
+  breadcrumbs: PropTypes.arrayOf(
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.objectOf(
+          PropTypes.oneOfType([
+            PropTypes.instanceOf(DeviceInfo),
+            PropTypes.instanceOf(StreamInfo)
+          ])
+        )
+      ])
+    )
+  ).isRequired,
   title: PropTypes.string.isRequired,
   deviceList: PropTypes.bool,
   children: PropTypes.oneOfType([

--- a/frontend/src/general/__tests__/DynamicBreadcrumb.test.jsx
+++ b/frontend/src/general/__tests__/DynamicBreadcrumb.test.jsx
@@ -1,0 +1,117 @@
+import React from "react";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+import { Box, Breadcrumbs, Link, Typography } from "@material-ui/core";
+import { NavLink } from "react-router-dom";
+import { NavigateNext } from "@material-ui/icons";
+import DeviceInfo from "../../model/DeviceInfo";
+import StreamInfo from "../../model/StreamInfo";
+import DynamicBreadcrumb from "../DynamicBreadcrumb";
+
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("<DynamicBreadcrumb/> functional component", ()=>{
+    let wrapper;
+    const objectBreadcrumb = [
+        "someDisplayName",
+        "somePathName",
+        {beep: new DeviceInfo("beep"),boop: new StreamInfo("boop") }
+    ]
+    const noObjectBreadcrumb = [
+        "someOtherDisplayName",
+        "someOtherPathName"
+    ]
+    const breadcrumbs = [objectBreadcrumb, noObjectBreadcrumb];
+
+    beforeEach(()=>{
+        wrapper = Enzyme.shallow(<DynamicBreadcrumb breadcrumbs={breadcrumbs}/>)
+    })
+    afterEach(()=>{
+        wrapper.unmount();
+    })
+    describe("returns a component that", ()=>{
+        it("Contains one <Box/> component with expected props", ()=>{
+            const components = wrapper.find(Box);
+            expect(components).toHaveLength(1);
+
+            const props = components.at(0).props();
+            
+            const expected = {
+                padding: "2em 0em 0em"
+            };
+            expect(props.padding).toBe(expected.padding);
+        })
+        it("Contains one <Breadcrumbs/> component with expected props", ()=>{
+            const components = wrapper.find(Breadcrumbs);
+            expect(components).toHaveLength(1);
+
+            const props = components.at(0).props();
+            
+            const expected = {
+                "aria-label": "breadcrumb",
+                separator: <NavigateNext fontSize="medium" />
+            };
+            expect(props).toMatchObject(expected);
+        })
+        it("Contains <Link/> components equal to number of crumbs passed", ()=>{
+            const components = wrapper.find(Link);
+            expect(components).toHaveLength(breadcrumbs.length);
+        })
+        it("<Link/> 0 has expected props", ()=>{
+            const components = wrapper.find(Link);
+
+            const props = components.at(0).props();
+            
+            const expected = {
+                component: NavLink,
+                to: {
+                    pathname: objectBreadcrumb[1],
+                    state: objectBreadcrumb[2]
+                }
+            };
+            expect(props).toMatchObject(expected);
+        })
+        it("<Link/> 1 has expected props", ()=>{
+            const components = wrapper.find(Link);
+
+            const props = components.at(1).props();
+            
+            const expected = {
+                component: NavLink,
+                to: {
+                    pathname: noObjectBreadcrumb[1],
+                    state: null
+                }
+            };
+            expect(props).toMatchObject(expected);
+        })
+        it("Contains <Typography/> components equal to number of crumbs passed", ()=>{
+            const components = wrapper.find(Typography);
+            expect(components).toHaveLength(breadcrumbs.length);
+        });
+        it("<Typography/> 1 components has expected props", ()=>{
+            const components = wrapper.find(Typography);
+            const props = components.at(0).props();
+            
+            const expected = {
+                color: "textPrimary",
+                children: objectBreadcrumb[0]
+            };
+            expect(props).toMatchObject(expected);
+        })
+        it("<Typography/> 1 components has expected props", ()=>{
+            const components = wrapper.find(Typography);
+            const props = components.at(1).props();
+            
+            const expected = {
+                color: "textPrimary",
+                children: noObjectBreadcrumb[0]
+            };
+            expect(props).toMatchObject(expected);
+        })
+    })
+
+})

--- a/frontend/src/general/__tests__/DynamicBreadcrumb.test.jsx
+++ b/frontend/src/general/__tests__/DynamicBreadcrumb.test.jsx
@@ -88,7 +88,7 @@ describe("<DynamicBreadcrumb/> functional component", () => {
       const components = wrapper.find(Typography);
       expect(components).toHaveLength(breadcrumbs.length);
     });
-    it("<Typography/> 1 components has expected props", () => {
+    it("<Typography/> 0 components has expected props", () => {
       const components = wrapper.find(Typography);
       const props = components.at(0).props();
 

--- a/frontend/src/general/__tests__/DynamicBreadcrumb.test.jsx
+++ b/frontend/src/general/__tests__/DynamicBreadcrumb.test.jsx
@@ -10,108 +10,103 @@ import DeviceInfo from "../../model/DeviceInfo";
 import StreamInfo from "../../model/StreamInfo";
 import DynamicBreadcrumb from "../DynamicBreadcrumb";
 
-
 Enzyme.configure({ adapter: new Adapter() });
 
-describe("<DynamicBreadcrumb/> functional component", ()=>{
-    let wrapper;
-    const objectBreadcrumb = [
-        "someDisplayName",
-        "somePathName",
-        {beep: new DeviceInfo("beep"),boop: new StreamInfo("boop") }
-    ]
-    const noObjectBreadcrumb = [
-        "someOtherDisplayName",
-        "someOtherPathName"
-    ]
-    const breadcrumbs = [objectBreadcrumb, noObjectBreadcrumb];
+describe("<DynamicBreadcrumb/> functional component", () => {
+  let wrapper;
+  const objectBreadcrumb = [
+    "someDisplayName",
+    "somePathName",
+    { beep: new DeviceInfo("beep"), boop: new StreamInfo("boop") }
+  ];
+  const noObjectBreadcrumb = ["someOtherDisplayName", "someOtherPathName"];
+  const breadcrumbs = [objectBreadcrumb, noObjectBreadcrumb];
 
-    beforeEach(()=>{
-        wrapper = Enzyme.shallow(<DynamicBreadcrumb breadcrumbs={breadcrumbs}/>)
-    })
-    afterEach(()=>{
-        wrapper.unmount();
-    })
-    describe("returns a component that", ()=>{
-        it("Contains one <Box/> component with expected props", ()=>{
-            const components = wrapper.find(Box);
-            expect(components).toHaveLength(1);
+  beforeEach(() => {
+    wrapper = Enzyme.shallow(<DynamicBreadcrumb breadcrumbs={breadcrumbs} />);
+  });
+  afterEach(() => {
+    wrapper.unmount();
+  });
+  describe("returns a component that", () => {
+    it("Contains one <Box/> component with expected props", () => {
+      const components = wrapper.find(Box);
+      expect(components).toHaveLength(1);
 
-            const props = components.at(0).props();
-            
-            const expected = {
-                padding: "2em 0em 0em"
-            };
-            expect(props.padding).toBe(expected.padding);
-        })
-        it("Contains one <Breadcrumbs/> component with expected props", ()=>{
-            const components = wrapper.find(Breadcrumbs);
-            expect(components).toHaveLength(1);
+      const props = components.at(0).props();
 
-            const props = components.at(0).props();
-            
-            const expected = {
-                "aria-label": "breadcrumb",
-                separator: <NavigateNext fontSize="medium" />
-            };
-            expect(props).toMatchObject(expected);
-        })
-        it("Contains <Link/> components equal to number of crumbs passed", ()=>{
-            const components = wrapper.find(Link);
-            expect(components).toHaveLength(breadcrumbs.length);
-        })
-        it("<Link/> 0 has expected props", ()=>{
-            const components = wrapper.find(Link);
+      const expected = {
+        padding: "2em 0em 0em"
+      };
+      expect(props.padding).toBe(expected.padding);
+    });
+    it("Contains one <Breadcrumbs/> component with expected props", () => {
+      const components = wrapper.find(Breadcrumbs);
+      expect(components).toHaveLength(1);
 
-            const props = components.at(0).props();
-            
-            const expected = {
-                component: NavLink,
-                to: {
-                    pathname: objectBreadcrumb[1],
-                    state: objectBreadcrumb[2]
-                }
-            };
-            expect(props).toMatchObject(expected);
-        })
-        it("<Link/> 1 has expected props", ()=>{
-            const components = wrapper.find(Link);
+      const props = components.at(0).props();
 
-            const props = components.at(1).props();
-            
-            const expected = {
-                component: NavLink,
-                to: {
-                    pathname: noObjectBreadcrumb[1],
-                    state: null
-                }
-            };
-            expect(props).toMatchObject(expected);
-        })
-        it("Contains <Typography/> components equal to number of crumbs passed", ()=>{
-            const components = wrapper.find(Typography);
-            expect(components).toHaveLength(breadcrumbs.length);
-        });
-        it("<Typography/> 1 components has expected props", ()=>{
-            const components = wrapper.find(Typography);
-            const props = components.at(0).props();
-            
-            const expected = {
-                color: "textPrimary",
-                children: objectBreadcrumb[0]
-            };
-            expect(props).toMatchObject(expected);
-        })
-        it("<Typography/> 1 components has expected props", ()=>{
-            const components = wrapper.find(Typography);
-            const props = components.at(1).props();
-            
-            const expected = {
-                color: "textPrimary",
-                children: noObjectBreadcrumb[0]
-            };
-            expect(props).toMatchObject(expected);
-        })
-    })
+      const expected = {
+        "aria-label": "breadcrumb",
+        separator: <NavigateNext fontSize="medium" />
+      };
+      expect(props).toMatchObject(expected);
+    });
+    it("Contains <Link/> components equal to number of crumbs passed", () => {
+      const components = wrapper.find(Link);
+      expect(components).toHaveLength(breadcrumbs.length);
+    });
+    it("<Link/> 0 has expected props", () => {
+      const components = wrapper.find(Link);
 
-})
+      const props = components.at(0).props();
+
+      const expected = {
+        component: NavLink,
+        to: {
+          pathname: objectBreadcrumb[1],
+          state: objectBreadcrumb[2]
+        }
+      };
+      expect(props).toMatchObject(expected);
+    });
+    it("<Link/> 1 has expected props", () => {
+      const components = wrapper.find(Link);
+
+      const props = components.at(1).props();
+
+      const expected = {
+        component: NavLink,
+        to: {
+          pathname: noObjectBreadcrumb[1],
+          state: null
+        }
+      };
+      expect(props).toMatchObject(expected);
+    });
+    it("Contains <Typography/> components equal to number of crumbs passed", () => {
+      const components = wrapper.find(Typography);
+      expect(components).toHaveLength(breadcrumbs.length);
+    });
+    it("<Typography/> 1 components has expected props", () => {
+      const components = wrapper.find(Typography);
+      const props = components.at(0).props();
+
+      const expected = {
+        color: "textPrimary",
+        children: objectBreadcrumb[0]
+      };
+      expect(props).toMatchObject(expected);
+    });
+    it("<Typography/> 1 components has expected props", () => {
+      const components = wrapper.find(Typography);
+      const props = components.at(1).props();
+
+      const expected = {
+        color: "textPrimary",
+        children: noObjectBreadcrumb[0]
+      };
+      expect(props).toMatchObject(expected);
+    });
+  });
+});

--- a/frontend/src/general/__tests__/Page.test.jsx
+++ b/frontend/src/general/__tests__/Page.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { beforeAll, describe, expect, it } from "@jest/globals";
-import { Box, Container } from "@material-ui/core";
+import { Container } from "@material-ui/core";
 import Page from "../Page";
 
 import Title from "../Title";

--- a/frontend/src/general/__tests__/Page.test.jsx
+++ b/frontend/src/general/__tests__/Page.test.jsx
@@ -39,10 +39,6 @@ describe("<Page/> functional Component", () => {
         expect(crumb.props().breadcrumbs[0][0]).toBe(dummyCrumb[0][0]);
         expect(crumb.props().breadcrumbs[0][1]).toBe(dummyCrumb[0][1]);
       });
-      it("Contains 1 <Box/> component with areaUnderBreacrumbs styling", () => {
-        expect(wrapper.find(Box)).toHaveLength(1);
-        expect(wrapper.find(Box).hasClass("areaUnderBreadcrumbs")).toBe(true);
-      });
       it("Contains 1 <Title/> component with expected props", () => {
         expect(wrapper.find(Title)).toHaveLength(1);
         const title = wrapper.find(Title).first();


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: <!--Issue Number--> Closes #451 

**Task description**: 

 - Breadcrumbs can now take a 3rd argument per crumb which allows you to pass a DeviceInfo or StreamInfo to the link you want to go to
 - change paddign because I didn't like how it looked
 - change separator icon to Next
 
<!-- What changed? What does this do? Provide screenshots if necessary--> 

| old | Updated|
|:---------------:|:---------------:|
|![image](https://user-images.githubusercontent.com/35614138/113620265-17f93b80-9628-11eb-8b75-6529ef6c3331.png)|![image](https://user-images.githubusercontent.com/35614138/113620089-d799bd80-9627-11eb-804e-7f80f46bc58e.png)|

## DESIGN DECISION PLEASE HELP
| Semi spaced  | compact |
|:---------------:|:---------------:|
|![image](https://user-images.githubusercontent.com/35614138/113619638-3ad72000-9627-11eb-8607-37546baa3532.png)|![image](https://user-images.githubusercontent.com/35614138/113619749-5fcb9300-9627-11eb-9976-59c981de3220.png)

# Testing

**Test coverage**:
<!-- Unit tested/manual testing only/ Some actual metrics -->

# Additional notes

**Note to reviewers**:
<!-- Special instructions for testing this code-->

**To do before merging**:
