### PR TITLE
[#486] Error snackbars displayed instead of sample data for DevicesTable and StreamsTable

### DIFF
--- a/frontend/src/api/DeviceApi.js
+++ b/frontend/src/api/DeviceApi.js
@@ -18,11 +18,11 @@ function getStatus(lastCommunicationString) {
   return "Offline";
 }
 
-export function getSenders(callback) {
-  axios
+export async function getSenders() {
+  return axios
     .get(process.env.REACT_APP_ENCODER, getAuthorizationHeader())
     .then((senders) => {
-      callback(
+      return Promise.resolve(
         senders.data.map((sender) => {
           let channels = [];
           if (sender.output) {
@@ -55,11 +55,11 @@ export function getSenders(callback) {
     });
 }
 
-export function getReceivers(callback) {
-  axios
+export async function getReceivers() {
+  return axios
     .get(process.env.REACT_APP_DECODER, getAuthorizationHeader())
     .then((receivers) => {
-      callback(
+      return Promise.resolve(
         receivers.data.map((receiver) => {
           let channels = [];
           if (receiver.input) {

--- a/frontend/src/api/DeviceApi.js
+++ b/frontend/src/api/DeviceApi.js
@@ -1,6 +1,5 @@
 import axios from "axios";
 import DeviceInfo from "../model/DeviceInfo";
-import * as SampleData from "./SampleData";
 import OutputChannelInfo from "../model/OutputChannelInfo";
 import InputChannelInfo from "../model/InputChannelInfo";
 import { getAuthorizationHeader } from "./AuthenticationUtil";
@@ -53,9 +52,6 @@ export function getSenders(callback) {
           );
         })
       );
-    })
-    .catch(() => {
-      SampleData.getSenders(callback);
     });
 }
 
@@ -93,9 +89,6 @@ export function getReceivers(callback) {
           );
         })
       );
-    })
-    .catch(() => {
-      SampleData.getReceivers(callback);
     });
 }
 

--- a/frontend/src/api/tests/DeviceApi.test.js
+++ b/frontend/src/api/tests/DeviceApi.test.js
@@ -36,7 +36,7 @@ describe("DeviceApi", () => {
         authorizationHeader
       );
 
-      expect(result).toEqual(DeviceFixture.getExpectedSendersResponse());
+      expect(result).toStrictEqual(DeviceFixture.getExpectedSendersResponse());
     });
   });
 
@@ -60,7 +60,7 @@ describe("DeviceApi", () => {
         authorizationHeader
       );
 
-      expect(result).toEqual(DeviceFixture.getExpectedReceiversResponse());
+      expect(result).toStrictEqual(DeviceFixture.getExpectedReceiversResponse());
     });
   });
 

--- a/frontend/src/api/tests/DeviceApi.test.js
+++ b/frontend/src/api/tests/DeviceApi.test.js
@@ -18,7 +18,7 @@ describe("DeviceApi", () => {
   });
 
   describe("getSenders", () => {
-    it("Should call axios and return the senders", (done) => {
+    it("Should call axios and return the senders", async () => {
       const sampleSendersResponse = DeviceFixture.getSampleSendersResponse();
       axios.get.mockResolvedValue({ data: sampleSendersResponse });
       authenticationUtil.getAuthorizationHeader = jest
@@ -30,23 +30,18 @@ describe("DeviceApi", () => {
           () => new Date(`${sampleSendersResponse[0].lastCommunication}Z`)
         );
 
-      DeviceApi.getSenders((result) => {
-        try {
-          expect(axios.get).toHaveBeenCalledWith(
-            "http://localhost:8080/encoder",
-            authorizationHeader
-          );
-          expect(result).toEqual(DeviceFixture.getExpectedSendersResponse());
-          done();
-        } catch (error) {
-          done(error);
-        }
-      });
+      const result = await DeviceApi.getSenders();
+      expect(axios.get).toHaveBeenCalledWith(
+        "http://localhost:8080/encoder",
+        authorizationHeader
+      );
+
+      expect(result).toEqual(DeviceFixture.getExpectedSendersResponse());
     });
   });
 
   describe("getReceivers", () => {
-    it("Should call axios and return the receivers", (done) => {
+    it("Should call axios and return the receivers", async () => {
       const sampleReceiversResponse = DeviceFixture.getSampleReceiversResponse();
       axios.get.mockResolvedValue({ data: sampleReceiversResponse });
       authenticationUtil.getAuthorizationHeader = jest
@@ -59,18 +54,13 @@ describe("DeviceApi", () => {
           () => new Date(`${sampleReceiversResponse[0].lastCommunication}Z`)
         );
 
-      DeviceApi.getReceivers((result) => {
-        try {
-          expect(axios.get).toHaveBeenCalledWith(
-            "http://localhost:8080/decoder",
-            authorizationHeader
-          );
-          expect(result).toEqual(DeviceFixture.getExpectedReceiversResponse());
-          done();
-        } catch (error) {
-          done(error);
-        }
-      });
+      const result = await DeviceApi.getReceivers();
+      expect(axios.get).toHaveBeenCalledWith(
+        "http://localhost:8080/decoder",
+        authorizationHeader
+      );
+
+      expect(result).toEqual(DeviceFixture.getExpectedReceiversResponse());
     });
   });
 

--- a/frontend/src/api/tests/DeviceApi.test.js
+++ b/frontend/src/api/tests/DeviceApi.test.js
@@ -60,7 +60,9 @@ describe("DeviceApi", () => {
         authorizationHeader
       );
 
-      expect(result).toStrictEqual(DeviceFixture.getExpectedReceiversResponse());
+      expect(result).toStrictEqual(
+        DeviceFixture.getExpectedReceiversResponse()
+      );
     });
   });
 

--- a/frontend/src/devicelist/DeviceListPageContents.jsx
+++ b/frontend/src/devicelist/DeviceListPageContents.jsx
@@ -3,6 +3,7 @@ import React from "react";
 import { getSenders, getReceivers } from "../api/DeviceApi";
 import DeviceTableTitle from "./DeviceTableTitle";
 import DevicesTable from "./DevicesTable";
+import { snackbar } from "../general/SnackbarMessage";
 
 export default class DeviceListPageContents extends React.Component {
   constructor(props) {
@@ -21,8 +22,16 @@ export default class DeviceListPageContents extends React.Component {
   }
 
   componentDidMount() {
-    getSenders(this.handleSendersChange);
-    getReceivers(this.handleReceiversChange);
+    getSenders()
+      .then(this.handleSendersChange)
+      .catch((error) => {
+        snackbar("error", `Failed to fetch senders: ${error.message}`);
+      });
+    getReceivers()
+      .then(this.handleReceiversChange)
+      .catch((error) => {
+        snackbar("error", `Failed to fetch receivers: ${error.message}`);
+      });
   }
 
   handleChange(value) {

--- a/frontend/src/devicelist/__tests__/DeviceListPageContents.test.jsx
+++ b/frontend/src/devicelist/__tests__/DeviceListPageContents.test.jsx
@@ -39,12 +39,8 @@ describe("<DeviceListPageContents/> class component", () => {
       });
     });
     it("calls DeviceApi.getSenders() and getReceivers()", () => {
-      jest.spyOn(DeviceApi, "getSenders").mockImplementation(() => {
-        return Promise.resolve(dummySenders);
-      });
-      jest.spyOn(DeviceApi, "getReceivers").mockImplementation(() => {
-        return Promise.resolve(dummyReceivers);
-      });
+      jest.spyOn(DeviceApi, "getSenders").mockResolvedValue(dummySenders);
+      jest.spyOn(DeviceApi, "getReceivers").mockResolvedValue(dummyReceivers);
 
       wrapper.instance().componentDidMount();
 
@@ -56,9 +52,7 @@ describe("<DeviceListPageContents/> class component", () => {
         message: "test"
       };
       jest.spyOn(DeviceApi, "getSenders").mockRejectedValue(returnedError);
-      jest.spyOn(DeviceApi, "getReceivers").mockImplementation(() => {
-        return Promise.resolve(dummyReceivers);
-      });
+      jest.spyOn(DeviceApi, "getReceivers").mockResolvedValue(dummyReceivers);
 
       wrapper.instance().componentDidMount();
 
@@ -75,9 +69,7 @@ describe("<DeviceListPageContents/> class component", () => {
       const returnedError = {
         message: "test"
       };
-      jest.spyOn(DeviceApi, "getSenders").mockImplementation(() => {
-        return Promise.resolve(dummySenders);
-      });
+      jest.spyOn(DeviceApi, "getSenders").mockResolvedValue(dummySenders);
       jest.spyOn(DeviceApi, "getReceivers").mockRejectedValue(returnedError);
 
       wrapper.instance().componentDidMount();
@@ -117,12 +109,8 @@ describe("<DeviceListPageContents/> class component", () => {
 
   describe("<DeviceListPageContents/> class functions", () => {
     beforeEach(() => {
-      jest.spyOn(DeviceApi, "getSenders").mockImplementation(() => {
-        return Promise.resolve(dummySenders);
-      });
-      jest.spyOn(DeviceApi, "getReceivers").mockImplementation(() => {
-        return Promise.resolve(dummyReceivers);
-      });
+      jest.spyOn(DeviceApi, "getSenders").mockResolvedValue(dummySenders);
+      jest.spyOn(DeviceApi, "getReceivers").mockResolvedValue(dummyReceivers);
       wrapper = Enzyme.shallow(<DeviceListPageContents />);
     });
 

--- a/frontend/src/devicelist/__tests__/DeviceListPageContents.test.jsx
+++ b/frontend/src/devicelist/__tests__/DeviceListPageContents.test.jsx
@@ -15,9 +15,12 @@ import DeviceTableTitle from "../DeviceTableTitle";
 import DevicesTable from "../DevicesTable";
 
 import * as DeviceApi from "../../api/DeviceApi";
+import * as SnackbarMessage from "../../general/SnackbarMessage";
 import DeviceInfo from "../../model/DeviceInfo";
 
 Enzyme.configure({ adapter: new Adapter() });
+
+const snackbarSpy = jest.spyOn(SnackbarMessage, "snackbar");
 
 describe("<DeviceListPageContents/> class component", () => {
   let wrapper;
@@ -30,167 +33,232 @@ describe("<DeviceListPageContents/> class component", () => {
   });
 
   describe("componentDidMount() function", () => {
-    it("calls DeviceApi.getSenders() and getReceivers()", () => {
-      jest.spyOn(DeviceApi, "getSenders").mockImplementation(() => {
-        return dummySenders;
-      });
-      jest.spyOn(DeviceApi, "getReceivers").mockImplementation(() => {
-        return dummyReceivers;
-      });
+    beforeEach(() => {
       wrapper = Enzyme.shallow(<DeviceListPageContents />, {
         disableLifecycleMethods: true
       });
+    });
+    it("calls DeviceApi.getSenders() and getReceivers()", () => {
+      jest.spyOn(DeviceApi, "getSenders").mockImplementation(() => {
+        return Promise.resolve(dummySenders);
+      });
+      jest.spyOn(DeviceApi, "getReceivers").mockImplementation(() => {
+        return Promise.resolve(dummyReceivers);
+      });
+
       wrapper.instance().componentDidMount();
 
-      expect(DeviceApi.getSenders).toHaveBeenCalledWith(
-        wrapper.instance().handleSendersChange
-      );
-      expect(DeviceApi.getReceivers).toHaveBeenCalledWith(
-        wrapper.instance().handleReceiversChange
-      );
+      expect(DeviceApi.getSenders).toHaveBeenCalled();
+      expect(DeviceApi.getReceivers).toHaveBeenCalled();
     });
-  });
-  describe("handleChange()", () => {
-    beforeEach(() => {
-      wrapper = Enzyme.shallow(<DeviceListPageContents />);
-    });
-    it("should set the state", () => {
-      const startingState = {
-        selected: 0,
-        senders: [],
-        receivers: []
+    it("if getSenders() rejects, an error snackbar with the caught error message is displayed", async () => {
+      const returnedError = {
+        message: "test"
       };
+      jest.spyOn(DeviceApi, "getSenders").mockRejectedValue(returnedError);
+      jest.spyOn(DeviceApi, "getReceivers").mockImplementation(() => {
+        return Promise.resolve(dummyReceivers);
+      });
 
-      const expectedValue = 5;
+      wrapper.instance().componentDidMount();
 
-      wrapper.setState(startingState);
+      await new Promise(setImmediate);
 
-      wrapper.instance().handleChange(expectedValue);
-      expect(wrapper.state().selected).toStrictEqual(expectedValue);
-    });
-  });
-  describe("handleSendersChange()", () => {
-    beforeEach(() => {
-      wrapper = Enzyme.shallow(<DeviceListPageContents />);
-    });
-    it("should set the state", () => {
-      const startingState = {
-        selected: 0,
-        senders: [],
-        receivers: []
-      };
+      expect(DeviceApi.getReceivers).toHaveBeenCalled();
 
-      const expectedValue = [new DeviceInfo("thing!")];
-
-      wrapper.setState(startingState);
-
-      wrapper.instance().handleSendersChange(expectedValue);
-      expect(wrapper.state().senders).toStrictEqual(expectedValue);
-    });
-  });
-  describe("handleReceiversChange()", () => {
-    beforeEach(() => {
-      wrapper = Enzyme.shallow(<DeviceListPageContents />);
-    });
-    it("should set the state", () => {
-      const startingState = {
-        selected: 0,
-        senders: [],
-        receivers: []
-      };
-
-      const expectedValue = [new DeviceInfo("thing!")];
-
-      wrapper.setState(startingState);
-
-      wrapper.instance().handleReceiversChange(expectedValue);
-      expect(wrapper.state().receivers).toStrictEqual(expectedValue);
-    });
-  });
-  describe("getDevices() function", () => {
-    beforeEach(() => {
-      wrapper = Enzyme.shallow(<DeviceListPageContents />);
-    });
-    it("if state.selected == 0, returns and array that combines state.senders and state.receivers ", () => {
-      const someState = {
-        selected: 0,
-        senders: dummySenders,
-        receivers: dummyReceivers
-      };
-      wrapper.setState(someState);
-      const result = wrapper.instance().getDevices();
-
-      expect(result).toStrictEqual(
-        someState.senders.concat(someState.receivers)
+      expect(snackbarSpy).toHaveBeenCalledWith(
+        "error",
+        `Failed to fetch senders: ${returnedError.message}`
       );
     });
-    it("if state.selected == 1, returns state.senders ", () => {
-      const someState = {
-        selected: 1,
-        senders: dummySenders,
-        receivers: dummyReceivers
+    it("if getReceivers() rejects, an error snackbar with the caught error message is displayed", async () => {
+      const returnedError = {
+        message: "test"
       };
-      wrapper.setState(someState);
-      const result = wrapper.instance().getDevices();
+      jest.spyOn(DeviceApi, "getSenders").mockImplementation(() => {
+        return Promise.resolve(dummySenders);
+      });
+      jest.spyOn(DeviceApi, "getReceivers").mockRejectedValue(returnedError);
 
-      expect(result).toStrictEqual(someState.senders);
+      wrapper.instance().componentDidMount();
+
+      await new Promise(setImmediate);
+
+      expect(DeviceApi.getSenders).toHaveBeenCalled();
+
+      expect(snackbarSpy).toHaveBeenCalledWith(
+        "error",
+        `Failed to fetch receivers: ${returnedError.message}`
+      );
     });
-    it("if state.selected == 2, returns state.receivers ", () => {
-      const someState = {
-        selected: 2,
-        senders: dummySenders,
-        receivers: dummyReceivers
+    it("if getReceivers() and getSenders() rejects, two error snackbars with the caught error message are displayed", async () => {
+      const returnedError = {
+        message: "test"
       };
-      wrapper.setState(someState);
-      const result = wrapper.instance().getDevices();
 
-      expect(result).toStrictEqual(someState.receivers);
+      jest.spyOn(DeviceApi, "getSenders").mockRejectedValue(returnedError);
+      jest.spyOn(DeviceApi, "getReceivers").mockRejectedValue(returnedError);
+
+      wrapper.instance().componentDidMount();
+
+      await new Promise(setImmediate);
+
+      expect(snackbarSpy).toHaveBeenCalledTimes(2);
+      expect(snackbarSpy).toHaveBeenCalledWith(
+        "error",
+        `Failed to fetch senders: ${returnedError.message}`
+      );
+      expect(snackbarSpy).toHaveBeenCalledWith(
+        "error",
+        `Failed to fetch receivers: ${returnedError.message}`
+      );
     });
   });
-  describe("getTitle() function", () => {
-    it("returns a <DeviceTableTitle/> component with expected props", () => {
-      wrapper = Enzyme.shallow(<DeviceListPageContents />);
-      const expected = {
-        index: wrapper.state().selected,
-        handleChange: wrapper.instance().handleChange
-      };
-      const deviceTableTitle = wrapper.instance().getTitle();
-      expect(deviceTableTitle.type).toEqual(DeviceTableTitle);
 
-      const wrap = Enzyme.shallow(deviceTableTitle);
-
-      const { props } = wrap.instance();
-      expect(props.index).toBe(expected.index);
-      expect(props.handleChange).toStrictEqual(expected.handleChange);
-    });
-  });
-  describe("render() function", () => {
+  describe("<DeviceListPageContents/> class functions", () => {
     beforeEach(() => {
+      jest.spyOn(DeviceApi, "getSenders").mockImplementation(() => {
+        return Promise.resolve(dummySenders);
+      });
+      jest.spyOn(DeviceApi, "getReceivers").mockImplementation(() => {
+        return Promise.resolve(dummyReceivers);
+      });
       wrapper = Enzyme.shallow(<DeviceListPageContents />);
     });
-    describe("returns a component that", () => {
-      it("Contains 1 <DevicesTable/> component with expected props", () => {
+
+    describe("handleChange() function", () => {
+      it("should set the state", () => {
+        const startingState = {
+          selected: 0,
+          senders: [],
+          receivers: []
+        };
+
+        const expectedValue = 5;
+
+        wrapper.setState(startingState);
+
+        wrapper.instance().handleChange(expectedValue);
+        expect(wrapper.state().selected).toStrictEqual(expectedValue);
+      });
+    });
+
+    describe("handleSendersChange() function", () => {
+      it("should set the state", () => {
+        const startingState = {
+          selected: 0,
+          senders: [],
+          receivers: []
+        };
+
+        const expectedValue = [new DeviceInfo("thing!")];
+
+        wrapper.setState(startingState);
+
+        wrapper.instance().handleSendersChange(expectedValue);
+        expect(wrapper.state().senders).toStrictEqual(expectedValue);
+      });
+    });
+
+    describe("handleReceiversChange() function", () => {
+      it("should set the state", () => {
+        const startingState = {
+          selected: 0,
+          senders: [],
+          receivers: []
+        };
+
+        const expectedValue = [new DeviceInfo("thing!")];
+
+        wrapper.setState(startingState);
+
+        wrapper.instance().handleReceiversChange(expectedValue);
+        expect(wrapper.state().receivers).toStrictEqual(expectedValue);
+      });
+    });
+
+    describe("getDevices() function", () => {
+      it("if state.selected == 0, returns and array that combines state.senders and state.receivers ", () => {
         const someState = {
           selected: 0,
           senders: dummySenders,
           receivers: dummyReceivers
         };
         wrapper.setState(someState);
+        const result = wrapper.instance().getDevices();
 
-        const component = wrapper.find(DevicesTable);
-        expect(component).toHaveLength(1);
-        const expected = {
-          devices: dummySenders.concat(dummyReceivers),
-          title: (
-            <DeviceTableTitle
-              index={0}
-              handleChange={wrapper.instance().handleChange}
-            />
-          )
+        expect(result).toStrictEqual(
+          someState.senders.concat(someState.receivers)
+        );
+      });
+      it("if state.selected == 1, returns state.senders ", () => {
+        const someState = {
+          selected: 1,
+          senders: dummySenders,
+          receivers: dummyReceivers
         };
-        const props = component.at(0).props();
-        expect(props.devices).toStrictEqual(expected.devices);
-        expect(props.title).toStrictEqual(expected.title);
+        wrapper.setState(someState);
+        const result = wrapper.instance().getDevices();
+
+        expect(result).toStrictEqual(someState.senders);
+      });
+      it("if state.selected == 2, returns state.receivers ", () => {
+        const someState = {
+          selected: 2,
+          senders: dummySenders,
+          receivers: dummyReceivers
+        };
+        wrapper.setState(someState);
+        const result = wrapper.instance().getDevices();
+
+        expect(result).toStrictEqual(someState.receivers);
+      });
+    });
+
+    describe("getTitle() function", () => {
+      it("returns a <DeviceTableTitle/> component with expected props", () => {
+        wrapper = Enzyme.shallow(<DeviceListPageContents />);
+
+        const expected = {
+          index: wrapper.state().selected,
+          handleChange: wrapper.instance().handleChange
+        };
+        const deviceTableTitle = wrapper.instance().getTitle();
+        expect(deviceTableTitle.type).toEqual(DeviceTableTitle);
+
+        const wrap = Enzyme.shallow(deviceTableTitle);
+
+        const { props } = wrap.instance();
+        expect(props.index).toBe(expected.index);
+        expect(props.handleChange).toStrictEqual(expected.handleChange);
+      });
+    });
+
+    describe("render() function", () => {
+      describe("returns a component that", () => {
+        it("Contains 1 <DevicesTable/> component with expected props", () => {
+          const someState = {
+            selected: 0,
+            senders: dummySenders,
+            receivers: dummyReceivers
+          };
+          wrapper.setState(someState);
+
+          const component = wrapper.find(DevicesTable);
+          expect(component).toHaveLength(1);
+          const expected = {
+            devices: dummySenders.concat(dummyReceivers),
+            title: (
+              <DeviceTableTitle
+                index={0}
+                handleChange={wrapper.instance().handleChange}
+              />
+            )
+          };
+          const props = component.at(0).props();
+          expect(props.devices).toStrictEqual(expected.devices);
+          expect(props.title).toStrictEqual(expected.title);
+        });
       });
     });
   });

--- a/frontend/src/streamlist/StreamsTableWrapper.jsx
+++ b/frontend/src/streamlist/StreamsTableWrapper.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import StreamsTable from "./StreamsTable";
-import { getAllStreams } from "../api/SampleData";
+import { snackbar } from "../general/SnackbarMessage";
 
 export default class StreamsTableWrapper extends React.Component {
   constructor(props) {
@@ -17,8 +17,8 @@ export default class StreamsTableWrapper extends React.Component {
     this.dataSource
       .getAllStreams()
       .then(this.handleStreamsChange)
-      .catch(() => {
-        this.handleStreamsChange(getAllStreams());
+      .catch((error) => {
+        snackbar("error", `Failed to fetch stream data: ${error.message}`);
       });
   }
 

--- a/frontend/src/streamlist/StreamsTableWrapper.jsx
+++ b/frontend/src/streamlist/StreamsTableWrapper.jsx
@@ -18,7 +18,7 @@ export default class StreamsTableWrapper extends React.Component {
       .getAllStreams()
       .then(this.handleStreamsChange)
       .catch((error) => {
-        snackbar("error", `Failed to fetch stream data: ${error.message}`);
+        snackbar("error", `Failed to fetch streams: ${error.message}`);
       });
   }
 

--- a/frontend/src/streamlist/__tests__/StreamsTableWrapper.test.jsx
+++ b/frontend/src/streamlist/__tests__/StreamsTableWrapper.test.jsx
@@ -40,32 +40,6 @@ describe("<StreamsTableWrapper/> component", () => {
     jest.clearAllMocks();
   });
 
-  describe("render() function", () => {
-    beforeEach(() => {
-      dummySource.getAllStreams.mockResolvedValue(dummyStream);
-      wrapper = Enzyme.shallow(
-        <StreamsTableWrapper dataSource={dummySource} columns={dummyColumns} />
-      );
-    });
-    describe("Should contain the following component", () => {
-      it("contains 1 <StreamsTable/> component with expected props", () => {
-        const table = wrapper.find(StreamsTable);
-        expect(table).toHaveLength(1);
-
-        const wrapperProps = wrapper.props();
-        const wrapperState = wrapper.state();
-        const expected = {
-          columns: wrapperProps.columns,
-          streams: wrapperState.streams
-        };
-
-        const tableProps = table.props();
-        expect(tableProps.columns).toBe(expected.columns);
-        expect(tableProps.streams).toBe(expected.streams);
-      });
-    });
-  });
-
   describe("componentDidMount() function", () => {
     beforeEach(() => {
       wrapper = Enzyme.shallow(
@@ -109,31 +83,53 @@ describe("<StreamsTableWrapper/> component", () => {
 
       expect(snackbarSpy).toHaveBeenCalledWith(
         "error",
-        `Failed to fetch stream data: ${returnedError.message}`
+        `Failed to fetch streams: ${returnedError.message}`
       );
     });
   });
 
-  describe("handleStreamsChange()", () => {
+  describe("<StreamsTableWrapper class functions", () => {
     beforeEach(() => {
       dummySource.getAllStreams.mockResolvedValue(dummyStream);
       wrapper = Enzyme.shallow(
         <StreamsTableWrapper dataSource={dummySource} columns={dummyColumns} />
       );
     });
-    it("should set the state streams", () => {
-      const testValue = [new StreamInfo()];
+    describe("handleStreamsChange()", () => {
+      it("should set the state streams", () => {
+        const testValue = [new StreamInfo()];
 
-      const defaultState = {
-        streams: dummyStream
-      };
-      const expectedState = {
-        streams: testValue
-      };
+        const defaultState = {
+          streams: dummyStream
+        };
+        const expectedState = {
+          streams: testValue
+        };
 
-      expect(wrapper.state()).toEqual(defaultState);
-      wrapper.instance().handleStreamsChange(testValue);
-      expect(wrapper.state()).toEqual(expectedState);
+        expect(wrapper.state()).toEqual(defaultState);
+        wrapper.instance().handleStreamsChange(testValue);
+        expect(wrapper.state()).toEqual(expectedState);
+      });
+    });
+
+    describe("render() function", () => {
+      describe("Should contain the following component", () => {
+        it("contains 1 <StreamsTable/> component with expected props", () => {
+          const table = wrapper.find(StreamsTable);
+          expect(table).toHaveLength(1);
+
+          const wrapperProps = wrapper.props();
+          const wrapperState = wrapper.state();
+          const expected = {
+            columns: wrapperProps.columns,
+            streams: wrapperState.streams
+          };
+
+          const tableProps = table.props();
+          expect(tableProps.columns).toBe(expected.columns);
+          expect(tableProps.streams).toBe(expected.streams);
+        });
+      });
     });
   });
 });

--- a/frontend/src/streamlist/__tests__/StreamsTableWrapper.test.jsx
+++ b/frontend/src/streamlist/__tests__/StreamsTableWrapper.test.jsx
@@ -1,19 +1,21 @@
 import React from "react";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import StreamsTableWrapper from "../StreamsTableWrapper";
 import StreamsTable from "../StreamsTable";
 import StreamInfo from "../../model/StreamInfo";
+import * as SnackbarMessage from "../../general/SnackbarMessage";
 
 Enzyme.configure({ adapter: new Adapter() });
 
+const snackbarSpy = jest.spyOn(SnackbarMessage, "snackbar");
+
 describe("<StreamsTableWrapper/> component", () => {
   let wrapper;
+  const dummyStream = [new StreamInfo(1, null, null, null, null)];
   const dummySource = {
-    getAllStreams() {
-      return Promise.resolve([]);
-    }
+    getAllStreams: jest.fn()
   };
   const dummyColumns = [
     {
@@ -26,40 +28,94 @@ describe("<StreamsTableWrapper/> component", () => {
     }
   ];
 
-  beforeEach(() => {
-    wrapper = Enzyme.shallow(
-      <StreamsTableWrapper dataSource={dummySource} columns={dummyColumns} />
-    );
-  });
-
   afterEach(() => {
     wrapper.unmount();
+    jest.clearAllMocks();
   });
 
-  describe("Should contain the following component", () => {
-    it("contains 1 <StreamsTable/> component with expected props", () => {
-      const table = wrapper.find(StreamsTable);
-      expect(table).toHaveLength(1);
+  describe("render() function", () => {
+    beforeEach(() => {
+      dummySource.getAllStreams.mockResolvedValue(dummyStream);
+      wrapper = Enzyme.shallow(
+        <StreamsTableWrapper dataSource={dummySource} columns={dummyColumns} />
+      );
+    });
+    describe("Should contain the following component", () => {
+      it("contains 1 <StreamsTable/> component with expected props", () => {
+        const table = wrapper.find(StreamsTable);
+        expect(table).toHaveLength(1);
 
-      const wrapperProps = wrapper.props();
-      const wrapperState = wrapper.state();
-      const expected = {
-        columns: wrapperProps.columns,
-        streams: wrapperState.streams
+        const wrapperProps = wrapper.props();
+        const wrapperState = wrapper.state();
+        const expected = {
+          columns: wrapperProps.columns,
+          streams: wrapperState.streams
+        };
+
+        const tableProps = table.props();
+        expect(tableProps.columns).toBe(expected.columns);
+        expect(tableProps.streams).toBe(expected.streams);
+      });
+    });
+  });
+
+  describe("componentDidMount() function", () => {
+    beforeEach(() => {
+      wrapper = Enzyme.shallow(
+        <StreamsTableWrapper dataSource={dummySource} columns={dummyColumns} />,
+        {
+          disableLifecycleMethods: true
+        }
+      );
+    });
+
+    it("calls the passed dataSource's getAllStreams()", () => {
+      dummySource.getAllStreams.mockResolvedValue(dummyStream);
+
+      wrapper.instance().componentDidMount();
+
+      expect(dummySource.getAllStreams).toHaveBeenCalledTimes(1);
+    });
+    it("passes the resolved streams to handleStreamsChange()", async () => {
+      dummySource.getAllStreams.mockResolvedValue(dummyStream);
+
+      const handleStreamsSpy = jest.spyOn(wrapper.instance(), "handleStreamsChange");
+
+      wrapper.instance().componentDidMount();
+
+      await new Promise(setImmediate);
+
+      expect(handleStreamsSpy).toHaveBeenCalledWith(dummyStream);
+    });
+    it("if it rejects, an error snackbar with the caught error message is displayed", async () => {
+      const returnedError = {
+        message: "test"
       };
+      dummySource.getAllStreams.mockRejectedValue(returnedError);
 
-      const tableProps = table.props();
-      expect(tableProps.columns).toBe(expected.columns);
-      expect(tableProps.streams).toBe(expected.streams);
+      wrapper.instance().componentDidMount();
+
+      await new Promise(setImmediate);
+
+      expect(snackbarSpy).toHaveBeenCalledWith(
+        "error",
+        `Failed to fetch stream data: ${returnedError.message}`
+      );
     });
   });
 
   describe("handleStreamsChange()", () => {
+    beforeEach(() => {
+      dummySource.getAllStreams.mockResolvedValue(dummyStream);
+      wrapper = Enzyme.shallow(
+        <StreamsTableWrapper dataSource={dummySource} columns={dummyColumns} />
+      );
+    });
     it("should set the state streams", () => {
       const testValue = [new StreamInfo()];
 
       const defaultState = {
-        streams: []
+        streams: dummyStream
       };
       const expectedState = {
         streams: testValue

--- a/frontend/src/streamlist/__tests__/StreamsTableWrapper.test.jsx
+++ b/frontend/src/streamlist/__tests__/StreamsTableWrapper.test.jsx
@@ -106,9 +106,9 @@ describe("<StreamsTableWrapper/> component", () => {
           streams: testValue
         };
 
-        expect(wrapper.state()).toEqual(defaultState);
+        expect(wrapper.state()).toStrictEqual(defaultState);
         wrapper.instance().handleStreamsChange(testValue);
-        expect(wrapper.state()).toEqual(expectedState);
+        expect(wrapper.state()).toStrictEqual(expectedState);
       });
     });
 
@@ -126,8 +126,7 @@ describe("<StreamsTableWrapper/> component", () => {
           };
 
           const tableProps = table.props();
-          expect(tableProps.columns).toBe(expected.columns);
-          expect(tableProps.streams).toBe(expected.streams);
+          expect(tableProps).toStrictEqual(expected);
         });
       });
     });

--- a/frontend/src/streamlist/__tests__/StreamsTableWrapper.test.jsx
+++ b/frontend/src/streamlist/__tests__/StreamsTableWrapper.test.jsx
@@ -1,7 +1,14 @@
 import React from "react";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest
+} from "@jest/globals";
 import StreamsTableWrapper from "../StreamsTableWrapper";
 import StreamsTable from "../StreamsTable";
 import StreamInfo from "../../model/StreamInfo";
@@ -79,7 +86,10 @@ describe("<StreamsTableWrapper/> component", () => {
     it("passes the resolved streams to handleStreamsChange()", async () => {
       dummySource.getAllStreams.mockResolvedValue(dummyStream);
 
-      const handleStreamsSpy = jest.spyOn(wrapper.instance(), "handleStreamsChange");
+      const handleStreamsSpy = jest.spyOn(
+        wrapper.instance(),
+        "handleStreamsChange"
+      );
 
       wrapper.instance().componentDidMount();
 


### PR DESCRIPTION
# General info

**Issue number**: closes #486 

**Task description**: 
- Error snackbars displayed instead of sample data for DevicesTable and StreamsTable
- DeviceApi now returns promises instead of using callbacks

# Testing

**Test coverage**:

# Additional notes

**Note to reviewers**:
N/A

**To do before merging**:
N/A