### PR TITLE
[#484] Resize some log table columns and set dateTime field default sort to descending

### DIFF
--- a/frontend/src/deviceDetailsPage/DeviceLogTableWrapper.jsx
+++ b/frontend/src/deviceDetailsPage/DeviceLogTableWrapper.jsx
@@ -13,18 +13,16 @@ export default class DeviceLogTableWrapper extends React.Component {
     this.columns = [
       {
         title: "ID",
-        field: "id",
-        cellStyle: { width: "5%" }
+        field: "id"
       },
       {
         title: "Date",
         field: "dateTime",
-        cellStyle: { width: "10%" }
+        defaultSort: "desc"
       },
       {
         title: "Level",
-        field: "level",
-        cellStyle: { width: "10%" }
+        field: "level"
       },
       {
         title: "Message",

--- a/frontend/src/deviceDetailsPage/DeviceLogTableWrapper.jsx
+++ b/frontend/src/deviceDetailsPage/DeviceLogTableWrapper.jsx
@@ -14,12 +14,12 @@ export default class DeviceLogTableWrapper extends React.Component {
       {
         title: "ID",
         field: "id",
-        cellStyle: { width: "10%" }
+        cellStyle: { width: "5%" }
       },
       {
         title: "Date",
         field: "dateTime",
-        cellStyle: { width: "15%" }
+        cellStyle: { width: "10%" }
       },
       {
         title: "Level",

--- a/frontend/src/deviceDetailsPage/__tests__/DeviceLogTableWrapper.test.jsx
+++ b/frontend/src/deviceDetailsPage/__tests__/DeviceLogTableWrapper.test.jsx
@@ -143,18 +143,16 @@ describe("<DeviceLogTableWrapper/> Class Component", () => {
       const expectedValue = [
         {
           title: "ID",
-          field: "id",
-          cellStyle: { width: "10%" }
+          field: "id"
         },
         {
           title: "Date",
           field: "dateTime",
-          cellStyle: { width: "15%" }
+          defaultSort: "desc"
         },
         {
           title: "Level",
-          field: "level",
-          cellStyle: { width: "10%" }
+          field: "level"
         },
         {
           title: "Message",

--- a/frontend/src/loglist/LogsTableWrapper.jsx
+++ b/frontend/src/loglist/LogsTableWrapper.jsx
@@ -13,12 +13,12 @@ export default class LogsTableWrapper extends React.Component {
       {
         title: "ID",
         field: "id",
-        cellStyle: { width: "10%" }
+        cellStyle: { width: "5%" }
       },
       {
         title: "Date",
         field: "dateTime",
-        cellStyle: { width: "15%" }
+        cellStyle: { width: "10%" }
       },
       {
         title: "Level",

--- a/frontend/src/loglist/LogsTableWrapper.jsx
+++ b/frontend/src/loglist/LogsTableWrapper.jsx
@@ -18,7 +18,8 @@ export default class LogsTableWrapper extends React.Component {
       {
         title: "Date",
         field: "dateTime",
-        cellStyle: { width: "10%" }
+        defaultSort: "desc",
+        cellStyle: { width: "15%" }
       },
       {
         title: "Level",

--- a/frontend/src/loglist/__tests__/LogsTableWrapper.test.jsx
+++ b/frontend/src/loglist/__tests__/LogsTableWrapper.test.jsx
@@ -135,11 +135,12 @@ describe("<LogsTableWrapper/> Class Component", () => {
         {
           title: "ID",
           field: "id",
-          cellStyle: { width: "10%" }
+          cellStyle: { width: "5%" }
         },
         {
           title: "Date",
           field: "dateTime",
+          defaultSort: "desc",
           cellStyle: { width: "15%" }
         },
         {

--- a/frontend/src/streamDetails/StreamLogTableWrapper.jsx
+++ b/frontend/src/streamDetails/StreamLogTableWrapper.jsx
@@ -13,12 +13,11 @@ export default class StreamLogTableWrapper extends React.Component {
       {
         title: "Date",
         field: "dateTime",
-        cellStyle: { width: "10%" }
+        defaultSort: "desc"
       },
       {
         title: "Level",
-        field: "level",
-        cellStyle: { width: "10%" }
+        field: "level"
       },
       {
         title: "Message",

--- a/frontend/src/streamDetails/StreamLogTableWrapper.jsx
+++ b/frontend/src/streamDetails/StreamLogTableWrapper.jsx
@@ -13,7 +13,7 @@ export default class StreamLogTableWrapper extends React.Component {
       {
         title: "Date",
         field: "dateTime",
-        cellStyle: { width: "15%" }
+        cellStyle: { width: "10%" }
       },
       {
         title: "Level",

--- a/frontend/src/streamDetails/__tests__/StreamLogTableWrapper.test.jsx
+++ b/frontend/src/streamDetails/__tests__/StreamLogTableWrapper.test.jsx
@@ -115,12 +115,11 @@ describe("<StreamLogsTableWrapper/> Class Component", () => {
         {
           title: "Date",
           field: "dateTime",
-          cellStyle: { width: "15%" }
+          defaultSort: "desc"
         },
         {
           title: "Level",
-          field: "level",
-          cellStyle: { width: "10%" }
+          field: "level"
         },
         {
           title: "Message",


### PR DESCRIPTION
# General info

**Issue number**: closes #484 

**Task description**: 
- Resize some log table columns
- Set dateTime field default sort to descending in log tables

# Testing

**Test coverage**: N/A

# Additional notes

**Note to reviewers**:
- Due to how narrow the device details and stream details logs cards are, I am unable to override the default widths of the table. Therefore I have just removed the cellStyling for all of those columns.

**To do before merging**:
N/A
