### PR TITLE
[#444] Make the Encoder Controller return api spec models

### DIFF
--- a/contracts/api-spec.yaml
+++ b/contracts/api-spec.yaml
@@ -244,7 +244,7 @@ paths:
 
   /encoder/{serialNumber}:
     get:
-      operationId: retrieveDecoder
+      operationId: retrieveEncoder
       description: Retrieve a specific encoder
       tags:
         - Encoders
@@ -659,6 +659,10 @@ components:
         serialNumber:
           type: string
           example: 'BtmC8ckj'
+        lastCommunication:
+          type: string
+          format: date-time
+          example: "2017-07-21T17:32:28Z"
         device:
           $ref: '#/components/schemas/DeviceModel'
         output:

--- a/contracts/api-spec.yaml
+++ b/contracts/api-spec.yaml
@@ -214,27 +214,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateEncoderRequest'
+              $ref: '#/components/schemas/EncoderModel'
       responses:
         '200':
           description: Successful creation the encoder
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EncoderModel'
-
-
-  /encoder/{serialNumber}:
-    get:
-      operationId: getEncoderById
-      description: Retrieve a specific encoder
-      tags:
-        - Encoders
-      parameters:
-        - $ref: '#/components/parameters/EncoderSerialNumber'
-      responses:
-        '200':
-          description: Successful retrieval of the encoder
           content:
             application/json:
               schema:
@@ -244,8 +227,6 @@ paths:
       description: Update a encoder's definition
       tags:
         - Encoders
-      parameters:
-        - $ref: '#/components/parameters/EncoderSerialNumber'
       requestBody:
         required: true
         content:
@@ -255,6 +236,23 @@ paths:
       responses:
         '200':
           description: Successful update of the Encoder
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncoderModel'
+
+
+  /encoder/{serialNumber}:
+    get:
+      operationId: retrieveDecoder
+      description: Retrieve a specific encoder
+      tags:
+        - Encoders
+      parameters:
+        - $ref: '#/components/parameters/EncoderSerialNumber'
+      responses:
+        '200':
+          description: Successful retrieval of the encoder
           content:
             application/json:
               schema:
@@ -269,6 +267,11 @@ paths:
       responses:
         '200':
           description: Successful deletion of the encoder
+          content:
+            application/json:
+              schema:
+                type: string
+                example: 'Encoder with serial number BtmC8ckj deleted'
 
   /encoder/{serialNumber}/stream:
     get:
@@ -662,13 +665,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/OutputChannelModel'
-
-    CreateEncoderRequest:
-      description: A client that sends a video stream
-      properties:
-        serialNumber:
-          type: string
-          example: 'BtmC8ckj'
 
     DecodersModel:
       description: A list of decoder UUIDs

--- a/src/main/java/org/beanpod/switchboard/controller/EncoderController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/EncoderController.java
@@ -35,7 +35,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/encoder")
 @RequiredArgsConstructor
 public class EncoderController implements EncoderApi {
 

--- a/src/main/java/org/beanpod/switchboard/controller/EncoderController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/EncoderController.java
@@ -62,7 +62,7 @@ public class EncoderController implements EncoderApi {
   }
 
   @Override
-  public ResponseEntity<EncoderModel> retrieveDecoder(@PathVariable @Valid String serialNumber) {
+  public ResponseEntity<EncoderModel> retrieveEncoder(@PathVariable @Valid String serialNumber) {
     UserEntity user = userDao.findUser(request.getUserPrincipal().getName());
 
     // maintain status field and create a log if status changed
@@ -137,6 +137,6 @@ public class EncoderController implements EncoderApi {
   }
 
   private RuntimeException getUnknownException() {
-    return new RuntimeException(UNKNOWN_ERROR_MESSAGE);
+    return new UnknownException(UNKNOWN_ERROR_MESSAGE);
   }
 }

--- a/src/main/java/org/beanpod/switchboard/controller/EncoderController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/EncoderController.java
@@ -24,7 +24,6 @@ import org.beanpod.switchboard.exceptions.ExceptionType.UnknownException;
 import org.beanpod.switchboard.service.EncoderService;
 import org.beanpod.switchboard.util.MaintainDeviceStatus;
 import org.openapitools.api.EncoderApi;
-import org.openapitools.model.CreateEncoderRequest;
 import org.openapitools.model.EncoderModel;
 import org.openapitools.model.StreamModel;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/beanpod/switchboard/controller/EncoderController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/EncoderController.java
@@ -56,7 +56,9 @@ public class EncoderController implements EncoderApi {
 
     List<EncoderEntity> encoderEntities = encoderDao.getEncoders(user);
     maintainDeviceStatus.maintainStatusField(encoderEntities);
-    return encoderMapper.toEncoderDtos(encoderEntities);
+    List<EncoderDto> encoderDtos = encoderMapper.toEncoderDtos(encoderEntities);
+    List<EncoderModel> encoderModels = encoderMapper.toEncoderModels(encoderDtos);
+    return ResponseEntity.ok(encoderModels);
   }
 
   @Override
@@ -75,6 +77,7 @@ public class EncoderController implements EncoderApi {
     }
     // return encoder
     return encoder
+        .map(encoderMapper::toEncoderModel)
         .map(ResponseEntity::ok)
         .orElseThrow(() -> new ExceptionType.DeviceNotFoundException(serialNumber));
   }
@@ -92,9 +95,12 @@ public class EncoderController implements EncoderApi {
     if (deviceOptional.isEmpty()) {
       throw new ExceptionType.DeviceNotFoundException(encoderModel.getSerialNumber());
     }
+    EncoderDto encoderDto = encoderMapper.toEncoderDto(encoderModel);
     encoderDto.setDevice(deviceOptional.get());
     encoderDto.setLastCommunication(Date.from(Instant.now()));
-    return ResponseEntity.ok(encoderDao.save(user, encoderDto));
+    EncoderDto savedEncoderDto = encoderDao.save(user, encoderDto);
+    EncoderModel savedEncoderModel = encoderMapper.toEncoderModel(savedEncoderDto);
+    return ResponseEntity.ok(savedEncoderModel);
   }
 
   @Override

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/DateMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/DateMapper.java
@@ -1,0 +1,16 @@
+package org.beanpod.switchboard.dto.mapper;
+
+import java.time.OffsetDateTime;
+import java.util.Date;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface DateMapper {
+  default Date toDate(OffsetDateTime offsetDateTime) {
+    return new Date(offsetDateTime.toInstant().toEpochMilli());
+  }
+
+  default OffsetDateTime toOffsetDateTime(Date date) {
+    return OffsetDateTime.from(date.toInstant());
+  }
+}

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/DateMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/DateMapper.java
@@ -1,16 +1,21 @@
 package org.beanpod.switchboard.dto.mapper;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface DateMapper {
   default Date toDate(OffsetDateTime offsetDateTime) {
+    if(offsetDateTime == null){
+      return null;
+    }
+
     return new Date(offsetDateTime.toInstant().toEpochMilli());
   }
 
   default OffsetDateTime toOffsetDateTime(Date date) {
-    return OffsetDateTime.from(date.toInstant());
+    return date.toInstant().atOffset(ZoneOffset.UTC);
   }
 }

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/EncoderMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/EncoderMapper.java
@@ -12,7 +12,7 @@ import org.openapitools.model.EncoderModel;
 
 @Mapper(
     componentModel = "spring",
-    uses = {DeviceMapper.class, OutputChannelMapper.class},
+    uses = {DeviceMapper.class, OutputChannelMapper.class, DateMapper.class},
     nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface EncoderMapper {
 

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/EncoderMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/EncoderMapper.java
@@ -8,12 +8,19 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.openapitools.model.EncoderModel;
 
 @Mapper(
     componentModel = "spring",
     uses = {DeviceMapper.class, OutputChannelMapper.class},
     nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface EncoderMapper {
+
+  EncoderModel toEncoderModel(EncoderDto encoderDto);
+
+  List<EncoderModel> toEncoderModels(List<EncoderDto> encoderDtos);
+
+  EncoderDto toEncoderDto(EncoderModel encoderModel);
 
   EncoderDto toEncoderDto(EncoderEntity encoderEntity);
 

--- a/src/main/java/org/beanpod/switchboard/dto/mapper/StreamMapper.java
+++ b/src/main/java/org/beanpod/switchboard/dto/mapper/StreamMapper.java
@@ -1,5 +1,6 @@
 package org.beanpod.switchboard.dto.mapper;
 
+import java.util.Date;
 import java.util.List;
 import org.beanpod.switchboard.dto.StreamDto;
 import org.beanpod.switchboard.entity.StreamEntity;
@@ -8,7 +9,7 @@ import org.openapitools.model.StreamModel;
 
 @Mapper(
     componentModel = "spring",
-    uses = {InputChannelMapper.class, OutputChannelMapper.class, StreamStatMapper.class})
+    uses = {InputChannelMapper.class, OutputChannelMapper.class, StreamStatMapper.class, DateMapper.class})
 public interface StreamMapper {
 
   StreamDto toDto(StreamModel streamModel);

--- a/src/test/java/org/beanpod/switchboard/dao/EncoderDaoImplTest.java
+++ b/src/test/java/org/beanpod/switchboard/dao/EncoderDaoImplTest.java
@@ -57,7 +57,7 @@ class EncoderDaoImplTest {
 
   @Test
   final void testSave() {
-    when(encoderMapper.toEncoderDto(any())).thenReturn(encoderDto);
+    when(encoderMapper.toEncoderDto(any(EncoderEntity.class))).thenReturn(encoderDto);
     when(encoderMapper.toEncoderEntity(any())).thenReturn(encoder);
     when(encoderRepository.save(encoder)).thenReturn(encoder);
     EncoderDto encoderDTO = encoderDaoImpl.save(user, encoderDto);
@@ -70,7 +70,7 @@ class EncoderDaoImplTest {
     EncoderDaoImpl encoderDaoImp1 = Mockito.spy(encoderDaoImp);
     Mockito.doReturn(Optional.of(encoderDto)).when(encoderDaoImp1).findEncoder(eq(user), any());
     when(encoderDaoImp.findEncoder(eq(user), any())).thenReturn(Optional.of(encoderDto));
-    when(encoderMapper.toEncoderDto(any())).thenReturn(encoderDto);
+    when(encoderMapper.toEncoderDto(any(EncoderEntity.class))).thenReturn(encoderDto);
     when(encoderMapper.toEncoderEntity(any())).thenReturn(encoder);
     when(encoderRepository.save(encoder)).thenReturn(encoder);
     EncoderDto encoderDTO = encoderDaoImp1.save(user, encoderDto);
@@ -79,7 +79,7 @@ class EncoderDaoImplTest {
 
   @Test
   final void testFindEncoder() {
-    when(encoderMapper.toEncoderDto(any())).thenReturn(encoderDto);
+    when(encoderMapper.toEncoderDto(any(EncoderEntity.class))).thenReturn(encoderDto);
     when(encoderMapper.toEncoderEntity(any())).thenReturn(encoder);
     when(encoderRepository.findEncoderByDeviceUserAndSerialNumber(
             user, EncoderFixture.SERIAL_NUMBER))

--- a/src/test/java/org/beanpod/switchboard/fixture/EncoderFixture.java
+++ b/src/test/java/org/beanpod/switchboard/fixture/EncoderFixture.java
@@ -1,6 +1,7 @@
 package org.beanpod.switchboard.fixture;
 
 import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -64,13 +65,23 @@ public class EncoderFixture {
   }
 
   public static EncoderModel getEncoderModel() {
-    return new EncoderModel().serialNumber(SERIAL_NUMBER).device(DeviceFixture.getDeviceModel());
+    return new EncoderModel()
+        .serialNumber(SERIAL_NUMBER)
+        .lastCommunication(OffsetDateTime.parse("2020-10-31T05:05:05Z"))
+        .device(DeviceFixture.getDeviceModel());
   }
 
   public static EncoderModel getEncoderModelWithOutputChannel() {
     return new EncoderModel()
         .serialNumber(SERIAL_NUMBER)
+        .lastCommunication(OffsetDateTime.parse("2020-10-31T05:05:05Z"))
         .device(DeviceFixture.getDeviceModel())
         .output(List.of(ChannelFixture.getOutputChannelModel()));
+  }
+
+  public static List<EncoderModel> getEncoderModels(){
+    return List.of(
+        getEncoderModelWithOutputChannel()
+    );
   }
 }


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->
This should fix the encoders returning the user's password hash

**Issue number**: #444 
**Task description**: 

 - Rewrite api spec
 - Implement the api spec in the Encoder Controller
 - Adapt the unit tests
 
# Testing

**Test coverage**:
Rewrote unit tests

# Additional notes
