### PR TITLE
Added @Transactional annotation on deleteStream method

### DIFF
--- a/src/main/java/org/beanpod/switchboard/controller/StreamController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/StreamController.java
@@ -21,6 +21,7 @@ import org.openapitools.model.CreateStreamRequest;
 import org.openapitools.model.StreamModel;
 import org.openapitools.model.StreamStatModel;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -85,6 +86,7 @@ public class StreamController implements StreamApi {
   }
 
   @Override
+  @Transactional
   public ResponseEntity<Void> deleteStream(Long id) {
     UserEntity user = userDao.findUser(request.getUserPrincipal().getName());
 


### PR DESCRIPTION
# General info
<!--Delete or put N/A for any irrelevant sections-->

**Issue number**: n/a

**Task description**: 

Fixes the following internal server error when deleting a stream:
`Resolved [org.springframework.dao.InvalidDataAccessApiUsageException: No EntityManager with actual transaction available for current thread - cannot reliably process ‘remove’ call; nested exception is javax.persistence.TransactionRequiredException: No EntityManager with actual transaction available for current thread - cannot reliably process ‘remove’ call]`

# Testing

**Test coverage**: n/a
<!-- Unit tested/manual testing only/ Some actual metrics -->

# Additional notes

**Note to reviewers**: n/a
<!-- Special instructions for testing this code-->

**To do before merging**: n/a
