### PR TITLE
Fix create logs for non-existent devices

### DIFF
--- a/src/main/java/org/beanpod/switchboard/controller/LogController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/LogController.java
@@ -5,9 +5,11 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.beanpod.switchboard.dao.DeviceDaoImpl;
 import org.beanpod.switchboard.dao.LogDaoImpl;
 import org.beanpod.switchboard.dao.StreamLogDaoImpl;
 import org.beanpod.switchboard.dao.UserDaoImpl;
+import org.beanpod.switchboard.dto.DeviceDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.dto.mapper.StreamLogMapper;
 import org.beanpod.switchboard.entity.UserEntity;
@@ -36,6 +38,7 @@ public class LogController implements LogApi {
   private final StreamLogService streamLogService;
   private final StreamLogMapper streamLogMapper;
   private final HttpServletRequest request;
+  private final DeviceDaoImpl deviceDao;
 
   @Override
   public ResponseEntity<List<StreamLogModel>> retrieveStreamLogs(@PathVariable Long streamId) {
@@ -57,6 +60,12 @@ public class LogController implements LogApi {
 
   @Override
   public ResponseEntity<LogModel> createLog(@Valid CreateLogRequest createLogRequest) {
+    Optional<DeviceDto> deviceLookup = deviceDao.findDevice(createLogRequest.getSerialNumber());
+
+    if (deviceLookup.isEmpty()) {
+      throw new ExceptionType.UnknownException(CONTROLLER_NAME);
+    }
+
     return Optional.of(createLogRequest)
         .map(logMapper::toModel)
         .map(logService::createLog)

--- a/src/main/java/org/beanpod/switchboard/controller/LogController.java
+++ b/src/main/java/org/beanpod/switchboard/controller/LogController.java
@@ -63,7 +63,7 @@ public class LogController implements LogApi {
     Optional<DeviceDto> deviceLookup = deviceDao.findDevice(createLogRequest.getSerialNumber());
 
     if (deviceLookup.isEmpty()) {
-      throw new ExceptionType.UnknownException(CONTROLLER_NAME);
+      throw new ExceptionType.DeviceNotFoundException(CONTROLLER_NAME);
     }
 
     return Optional.of(createLogRequest)

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -119,7 +119,7 @@ class LogControllerTest {
     when(logService.createLog(any())).thenReturn(logDto);
     when(logMapper.toModel((CreateLogRequest) any())).thenReturn(logModel);
     when(logMapper.toModel((LogDto) any())).thenReturn(logModel);
-    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER)).thenReturn(Optional.of(null));
+    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER)).thenReturn(Optional.empty());
 
     assertThrows(
         ExceptionType.UnknownException.class,

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -2,6 +2,7 @@ package org.beanpod.switchboard.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +20,7 @@ import org.beanpod.switchboard.dto.StreamLogDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.dto.mapper.StreamLogMapper;
 import org.beanpod.switchboard.entity.UserEntity;
+import org.beanpod.switchboard.exceptions.ExceptionType;
 import org.beanpod.switchboard.fixture.DeviceFixture;
 import org.beanpod.switchboard.fixture.LogFixture;
 import org.beanpod.switchboard.fixture.StreamLogFixture;
@@ -110,6 +112,18 @@ class LogControllerTest {
 
     assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
     assertEquals(logModel, responseEntity.getBody());
+  }
+
+  @Test
+  final void testCreateLogWhenNoDevice() {
+    when(logService.createLog(any())).thenReturn(logDto);
+    when(logMapper.toModel((CreateLogRequest) any())).thenReturn(logModel);
+    when(logMapper.toModel((LogDto) any())).thenReturn(logModel);
+    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER)).thenReturn(Optional.of(null));
+
+    assertThrows(
+        ExceptionType.UnknownException.class,
+        () -> logController.createLog(LogFixture.getCreateLogRequest()));
   }
 
   @Test

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -7,15 +7,19 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.attribute.UserPrincipal;
 import java.util.List;
+import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
+import org.beanpod.switchboard.dao.DeviceDaoImpl;
 import org.beanpod.switchboard.dao.LogDaoImpl;
 import org.beanpod.switchboard.dao.StreamLogDaoImpl;
 import org.beanpod.switchboard.dao.UserDaoImpl;
+import org.beanpod.switchboard.dto.DeviceDto;
 import org.beanpod.switchboard.dto.LogDto;
 import org.beanpod.switchboard.dto.StreamLogDto;
 import org.beanpod.switchboard.dto.mapper.LogMapper;
 import org.beanpod.switchboard.dto.mapper.StreamLogMapper;
 import org.beanpod.switchboard.entity.UserEntity;
+import org.beanpod.switchboard.fixture.DeviceFixture;
 import org.beanpod.switchboard.fixture.LogFixture;
 import org.beanpod.switchboard.fixture.StreamLogFixture;
 import org.beanpod.switchboard.fixture.UserFixture;
@@ -44,6 +48,7 @@ class LogControllerTest {
   private static StreamLogDto streamLogDto;
   private static StreamLogModel streamLogModel;
   private static UserEntity user;
+  private static DeviceDto deviceDTO;
   @InjectMocks private LogController logController;
   @Mock private LogDaoImpl logDao;
   @Mock private LogMapper logMapper;
@@ -54,6 +59,7 @@ class LogControllerTest {
   @Mock private HttpServletRequest httpServletRequest;
   @Mock private UserPrincipal userPrincipal;
   @Mock private UserDaoImpl userDao;
+  @Mock private DeviceDaoImpl deviceDao;
 
   @BeforeEach
   void setup() {
@@ -73,6 +79,7 @@ class LogControllerTest {
     streamLogDto = StreamLogFixture.getStreamLogDto();
     streamLogModel = StreamLogFixture.getStreamLogModel();
     user = UserFixture.getUserEntity();
+    deviceDTO = DeviceFixture.getDeviceDto();
   }
 
   @Test
@@ -96,6 +103,8 @@ class LogControllerTest {
     when(logService.createLog(any())).thenReturn(logDto);
     when(logMapper.toModel((CreateLogRequest) any())).thenReturn(logModel);
     when(logMapper.toModel((LogDto) any())).thenReturn(logModel);
+    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER))
+        .thenReturn(Optional.of(deviceDTO));
 
     ResponseEntity<LogModel> responseEntity =
         logController.createLog(LogFixture.getCreateLogRequest());

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -103,8 +103,7 @@ class LogControllerTest {
     when(logService.createLog(any())).thenReturn(logDto);
     when(logMapper.toModel((CreateLogRequest) any())).thenReturn(logModel);
     when(logMapper.toModel((LogDto) any())).thenReturn(logModel);
-    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER))
-        .thenReturn(Optional.of(deviceDTO));
+    when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER)).thenReturn(Optional.of(deviceDTO));
 
     ResponseEntity<LogModel> responseEntity =
         logController.createLog(LogFixture.getCreateLogRequest());

--- a/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
+++ b/src/test/java/org/beanpod/switchboard/controller/LogControllerTest.java
@@ -122,7 +122,7 @@ class LogControllerTest {
     when(deviceDao.findDevice(DeviceFixture.SERIAL_NUMBER)).thenReturn(Optional.empty());
 
     assertThrows(
-        ExceptionType.UnknownException.class,
+        ExceptionType.DeviceNotFoundException.class,
         () -> logController.createLog(LogFixture.getCreateLogRequest()));
   }
 


### PR DESCRIPTION
# General info
Logs were allowed to be created for any device without checking if the device actually existed. Now it's fixed!

**Issue number**: N/A

**Task description**: 
 - Retrieve the device that's associated with the serial number. If it doesn't exist, then an error is thrown.

# Testing
To ease the testing process, here's the request the you should test:
![/log endpoint postman request](https://user-images.githubusercontent.com/39838955/114295655-97e23400-9a74-11eb-8f3e-4d60777149dc.png)

You got two possibilities: 1- The device exists then the log should be created
2- The device doesn't exist then an error should be thrown